### PR TITLE
feat(vui-84): add color, variant, rearange docs & fix test.

### DIFF
--- a/packages/valko-ui-components/src/__test__/Breadcrumbs.spec.ts
+++ b/packages/valko-ui-components/src/__test__/Breadcrumbs.spec.ts
@@ -23,23 +23,23 @@ describe('Breadcrumbs component', () => {
       })
 
       it('should render', () => {
-        expect(wrapper.find('.vk-breadcrumbs')).toBeDefined()
+        expect(wrapper.find('.vk-breadcrumbs').exists()).toBe(true)
       })
 
       it('should be color primary', () => {
-        expect(wrapper.find('.bg-primary-500')).toBeDefined()
+        expect(wrapper.find('.vk-breadcrumbs__a').classes()).toContain('text-primary-500')
       })
 
       it('should be size md', () => {
-        expect(wrapper.find('.text-base')).toBeDefined()
+        expect(wrapper.find('.text-base').exists()).toBe(true)
       })
 
       it('should be variant filled', () => {
-        expect(wrapper.find('.bg-primary-500')).toBeDefined()
+        expect(wrapper.find('.vk-breadcrumbs').classes()).toContain('bg-light-3')
       })
 
       it('should be shape soft', () => {
-        expect(wrapper.find('.rounded-lg')).toBeDefined()
+        expect(wrapper.find('.rounded-lg').exists()).toBe(true)
       })
 
       it('should not be flat', () => {
@@ -56,7 +56,7 @@ describe('Breadcrumbs component', () => {
           }
         })
 
-        expect(wrapper.find('.bg-primary-500')).toBeDefined()
+        expect(wrapper.find('.text-primary-500').exists()).toBe(true)
       })
 
       it('should be color secondary when props.color is secondary', () => {
@@ -67,7 +67,7 @@ describe('Breadcrumbs component', () => {
           }
         })
 
-        expect(wrapper.find('.bg-secondary-500')).toBeDefined()
+        expect(wrapper.find('.text-secondary-500').exists()).toBe(true)
       })
 
       it('should be color success when props.color is success', () => {
@@ -78,7 +78,7 @@ describe('Breadcrumbs component', () => {
           }
         })
 
-        expect(wrapper.find('.bg-success-500')).toBeDefined()
+        expect(wrapper.find('.text-success-500').exists()).toBe(true)
       })
 
       it('should be color info when props.color is info', () => {
@@ -89,7 +89,7 @@ describe('Breadcrumbs component', () => {
           }
         })
 
-        expect(wrapper.find('.bg-info-500')).toBeDefined()
+        expect(wrapper.find('.text-info-500').exists()).toBe(true)
       })
 
       it('should be color warning when props.color is warning', () => {
@@ -100,7 +100,7 @@ describe('Breadcrumbs component', () => {
           }
         })
 
-        expect(wrapper.find('.bg-warning-500')).toBeDefined()
+        expect(wrapper.find('.text-warning-500').exists()).toBe(true)
       })
 
       it('should be color error when props.color is error', () => {
@@ -111,7 +111,7 @@ describe('Breadcrumbs component', () => {
           }
         })
 
-        expect(wrapper.find('.bg-error-500')).toBeDefined()
+        expect(wrapper.find('.text-error-500').exists()).toBe(true)
       })
 
       it('should be color light when props.color is light', () => {
@@ -122,7 +122,7 @@ describe('Breadcrumbs component', () => {
           }
         })
 
-        expect(wrapper.find('.bg-light-1')).toBeDefined()
+        expect(wrapper.find('.text-light-1').exists()).toBe(true)
       })
 
       it('should be color dark when props.color is dark', () => {
@@ -133,7 +133,18 @@ describe('Breadcrumbs component', () => {
           }
         })
 
-        expect(wrapper.find('.bg-dark-5')).toBeDefined()
+        expect(wrapper.find('.text-dark-5').exists()).toBe(true)
+      })
+
+      it('should be color neutral when props.color is neutral', () => {
+        wrapper = mount(VkBreadcrumbs, {
+          props: {
+            crumbs,
+            color: 'neutral'
+          }
+        })
+
+        expect(wrapper.find('.text-black').exists()).toBe(true)
       })
     })
 
@@ -146,7 +157,7 @@ describe('Breadcrumbs component', () => {
           }
         })
 
-        expect(wrapper.find('.rounded-full')).toBeDefined()
+        expect(wrapper.find('.rounded-full').exists()).toBe(true)
       })
 
       it('should be soft when props.shape is soft', () => {
@@ -157,7 +168,7 @@ describe('Breadcrumbs component', () => {
           }
         })
 
-        expect(wrapper.find('.rounded-lg')).toBeDefined()
+        expect(wrapper.find('.rounded-lg').exists()).toBe(true)
       })
 
       it('should be square when props.shape is square', () => {
@@ -168,7 +179,7 @@ describe('Breadcrumbs component', () => {
           }
         })
 
-        expect(wrapper.find('.rounded-none')).toBeDefined()
+        expect(wrapper.find('.rounded-none').exists()).toBe(true)
       })
     })
 
@@ -181,7 +192,7 @@ describe('Breadcrumbs component', () => {
           }
         })
 
-        expect(wrapper.find('.text-xs')).toBeDefined()
+        expect(wrapper.find('.text-xs').exists()).toBe(true)
       })
 
       it('should be sm when props.size is sm', () => {
@@ -192,7 +203,7 @@ describe('Breadcrumbs component', () => {
           }
         })
 
-        expect(wrapper.find('.text-sm')).toBeDefined()
+        expect(wrapper.find('.text-sm').exists()).toBe(true)
       })
 
       it('should be md when props.size is md', () => {
@@ -203,7 +214,7 @@ describe('Breadcrumbs component', () => {
           }
         })
 
-        expect(wrapper.find('.text-base')).toBeDefined()
+        expect(wrapper.find('.text-base').exists()).toBe(true)
       })
 
       it('should be lg when props.size is lg', () => {
@@ -214,7 +225,7 @@ describe('Breadcrumbs component', () => {
           }
         })
 
-        expect(wrapper.find('.text-lg')).toBeDefined()
+        expect(wrapper.find('.text-lg').exists()).toBe(true)
       })
     })
 
@@ -246,6 +257,17 @@ describe('Breadcrumbs component', () => {
           props: {
             crumbs,
             variant: 'ghost'
+          }
+        })
+
+        expect(wrapper.find('.vk-breadcrumbs').classes()).toContain('bg-light-3/[.50]')
+      })
+
+      it('should be link when props.size is link', () => {
+        wrapper = mount(VkBreadcrumbs, {
+          props: {
+            crumbs,
+            variant: 'link'
           }
         })
 

--- a/packages/valko-ui-components/src/components/Breadcrumbs.vue
+++ b/packages/valko-ui-components/src/components/Breadcrumbs.vue
@@ -27,12 +27,14 @@ const onCrumbClick = (item: Crumb) => {
   emit('crumbClick', item)
   item.onClick?.()
 }
+
+const useIcon = (separator: string) => separator.length > 2
 </script>
 
 <template>
   <div :class="classes.container">
     <a
-      v-for="crumb in props.crumbs"
+      v-for="crumb in crumbs"
       :key="crumb.key"
       :class="classes.a"
       :data-disabled="crumb.disabled"
@@ -52,7 +54,14 @@ const onCrumbClick = (item: Crumb) => {
       <span
         v-if="crumb.key !== lastCrumbKey"
         :class="classes.separator"
-      >{{ props.separator }}</span>
+      >
+        <template v-if="useIcon(separator)">
+          <vk-icon :name="separator" />
+        </template>
+        <template v-else>
+          {{ separator }}
+        </template>
+      </span>
     </a>
   </div>
 </template>

--- a/packages/valko-ui-components/src/styles/Breadcrumbs.styles.ts
+++ b/packages/valko-ui-components/src/styles/Breadcrumbs.styles.ts
@@ -49,6 +49,12 @@ export default tv({
       },
       ghost: {
         container: [
+          'bg-light-3/[.50]',
+          'dark:bg-dark-3/[.50]'
+        ]
+      },
+      link: {
+        container: [
           'bg-transparent'
         ]
       }
@@ -92,6 +98,12 @@ export default tv({
       dark: {
         a: [
           'text-dark-5'
+        ]
+      },
+      neutral: {
+        a: [
+          'text-black',
+          'dark:text-white'
         ]
       }
     },
@@ -139,7 +151,7 @@ export default tv({
     }
   },
   compoundVariants: [
-    // flat & variant
+    // flat & variants
     {
       variant: ['filled', 'outlined'],
       flat: false,

--- a/packages/valko-ui-components/src/types/Breadcrumbs.ts
+++ b/packages/valko-ui-components/src/types/Breadcrumbs.ts
@@ -1,4 +1,4 @@
-import type { DefaultComponent } from './common'
+import type { Shapes, Color, Sizes, Variant } from './common'
 
 export interface Crumb {
   key: string;
@@ -9,7 +9,9 @@ export interface Crumb {
   onClick?: () => void;
 }
 
-export interface BreadcrumbsProps extends DefaultComponent {
+export interface BreadcrumbsProps extends Shapes, Sizes {
+  variant?: Variant | 'link';
+  color?: Color | 'neutral';
   crumbs: Crumb[];
   separator?: string;
   flat?: boolean;

--- a/packages/valko-ui-docs/src/pages/docs/ui/BreadcrumbsPage.vue
+++ b/packages/valko-ui-docs/src/pages/docs/ui/BreadcrumbsPage.vue
@@ -19,6 +19,16 @@ const form = ref({
   flat: false
 })
 
+const variants = [
+  ...variantOptions,
+  { value: 'link', label: 'Link' }
+]
+
+const colors = [
+  ...colorOptions,
+  { value: 'neutral', label: 'Neutral' }
+]
+
 const crumbs = [
   { key: 'home', title: 'Home', onClick: () => useNotification({ text: 'Home' }) },
   { key: 'music', title: 'Music', onClick: () => useNotification({ text: 'Music' }) },
@@ -82,7 +92,7 @@ const breadcrumbsProps = [
   {
     prop: 'separator',
     required: false,
-    description: 'The separator for the Breadcrumbs.',
+    description: 'The separator for the Breadcrumbs. Up to 2 character or an icon if passed the name.',
     values: 'string',
     default: '>'
   },
@@ -171,13 +181,13 @@ const breadcrumbsEmits = [
       <vk-select
         placeholder="Color"
         size="sm"
-        :options="colorOptions"
+        :options="colors"
         v-model="form.color"
       />
       <vk-select
         placeholder="Variant"
         size="sm"
-        :options="variantOptions"
+        :options="variants"
         v-model="form.variant"
       />
       <vk-select
@@ -209,7 +219,7 @@ const breadcrumbsEmits = [
       >
         <div class="flex flex-wrap gap-4">
           <div
-            v-for="color in colorOptions"
+            v-for="color in colors"
             :key="color.value"
             class="flex flex-col gap-1"
           >
@@ -226,9 +236,9 @@ const breadcrumbsEmits = [
         title="Variants"
         gap
       >
-        <div class="flex flex-wrap gap-4">
+        <div class="grid grid-cols-2 gap-4">
           <div
-            v-for="variant in variantOptions"
+            v-for="variant in variants"
             :key="variant.value"
             class="flex flex-col gap-1"
           >
@@ -264,7 +274,7 @@ const breadcrumbsEmits = [
         title="Sizes"
         gap
       >
-        <div class="flex flex-wrap gap-4">
+        <div class="grid grid-cols-2 gap-4">
           <div
             v-for="size in sizeOptions"
             :key="size.value"


### PR DESCRIPTION
Add neutral color.
Make ghost variant style match the other components same variant.
Add variant link.
Make separator prop capable of using icons or given characters.
Props should have its own section like the other components docs (flat & icons should have its own section).
Fix/update test for breadcrumbs.