### PR TITLE
fix(vui-106): apply fixes to components.

### DIFF
--- a/packages/valko-ui-components/src/__test__/Checkbox.spec.ts
+++ b/packages/valko-ui-components/src/__test__/Checkbox.spec.ts
@@ -60,7 +60,7 @@ describe('Checkbox component', () => {
           }
         })
 
-        expect(wrapper.find('.vk-checkbox__checkbox').classes()).toContain('data-[checked=true]:bg-light-4')
+        expect(wrapper.find('.vk-checkbox__checkbox').classes()).toContain('data-[checked=true]:bg-dark-4')
       })
 
       it('should be color success when props.color is success', () => {

--- a/packages/valko-ui-components/src/__test__/Drawer.spec.ts
+++ b/packages/valko-ui-components/src/__test__/Drawer.spec.ts
@@ -37,7 +37,7 @@ describe('Drawer component', () => {
       })
 
       it('should be shape soft', () => {
-        expect(drawer.classes()).toContain('rounded-lg')
+        expect(drawer.classes()).toContain('rounded-l-lg')
       })
 
       it('should be size md', () => {
@@ -121,7 +121,7 @@ describe('Drawer component', () => {
         })
         await nextTick()
         drawer = wrapper.getComponent(DialogPanel) as unknown as VueWrapper
-        expect(drawer.classes()).toContain('rounded-2xl')
+        expect(drawer.classes()).toContain('rounded-l-2xl')
       })
 
       it('should be soft when props.shape is soft', async () => {
@@ -136,7 +136,7 @@ describe('Drawer component', () => {
         })
         await nextTick()
         drawer = wrapper.getComponent(DialogPanel) as unknown as VueWrapper
-        expect(drawer.classes()).toContain('rounded-lg')
+        expect(drawer.classes()).toContain('rounded-l-lg')
       })
 
       it('should be square when props.shape is square', async () => {

--- a/packages/valko-ui-components/src/__test__/Radio.spec.ts
+++ b/packages/valko-ui-components/src/__test__/Radio.spec.ts
@@ -64,7 +64,7 @@ describe('Radio component', () => {
           }
         })
 
-        expect(wrapper.find('.vk-radio__radio').classes()).toContain('data-[checked=true]:bg-light-4')
+        expect(wrapper.find('.vk-radio__radio').classes()).toContain('data-[checked=true]:bg-dark-4')
       })
 
       it('should be color success when props.color is success', () => {

--- a/packages/valko-ui-components/src/components/Drawer.vue
+++ b/packages/valko-ui-components/src/components/Drawer.vue
@@ -27,7 +27,7 @@ const classes = useStyle<DrawerProps, SlotStyles>(props, styles)
 
 const containerRef = ref(null)
 
-const closeDrawer = () => { emit('close') }
+const closeDrawer = () => { if (props.closable) emit('close') }
 
 const transitionClasses = computed(() => {
   switch (props.placement) {

--- a/packages/valko-ui-components/src/components/Modal.vue
+++ b/packages/valko-ui-components/src/components/Modal.vue
@@ -24,7 +24,7 @@ const classes = useStyle<ModalProps, SlotStyles>(props, styles)
 
 const containerRef = ref(null)
 
-const closeModal = () => { emit('close') }
+const closeModal = () => { if (props.closable) emit('close') }
 </script>
 
 <template>

--- a/packages/valko-ui-components/src/styles/Checkbox.styles.ts
+++ b/packages/valko-ui-components/src/styles/Checkbox.styles.ts
@@ -223,18 +223,18 @@ export default tv({
       disabled: false,
       class: {
         checkbox: [
-          'data-[checked=true]:bg-light-4',
-          'data-[checked=true]:border-light-4',
-          'data-[indeterminate=true]:border-light-4',
-          'data-[indeterminate=true]:bg-light-4',
-          'dark:data-[checked=true]:bg-dark-3',
-          'dark:data-[checked=true]:border-dark-3',
-          'dark:data-[indeterminate=true]:border-dark-3',
-          'dark:data-[indeterminate=true]:bg-dark-3'
+          'data-[checked=true]:bg-dark-4',
+          'data-[checked=true]:border-dark-4',
+          'data-[indeterminate=true]:border-dark-4',
+          'data-[indeterminate=true]:bg-dark-4',
+          'dark:data-[checked=true]:bg-light-3',
+          'dark:data-[checked=true]:border-light-3',
+          'dark:data-[indeterminate=true]:border-light-3',
+          'dark:data-[indeterminate=true]:bg-light-3'
         ],
         icon: [
-          'text-dark-1',
-          'dark:text-light-3'
+          'text-light-1',
+          'dark:text-dark-3'
         ]
       }
     },
@@ -330,10 +330,10 @@ export default tv({
       disabled: false,
       class: {
         checkbox: [
-          'data-[checked=true]:border-light-4',
-          'data-[indeterminate=true]:border-light-4',
-          'dark:data-[checked=true]:border-dark-3',
-          'dark:data-[indeterminate=true]:border-dark-3'
+          'data-[checked=true]:border-dark-4',
+          'data-[indeterminate=true]:border-dark-4',
+          'dark:data-[checked=true]:border-light-3',
+          'dark:data-[indeterminate=true]:border-light-3'
         ],
         icon: [
           'text-dark-1',

--- a/packages/valko-ui-components/src/styles/Drawer.styles.ts
+++ b/packages/valko-ui-components/src/styles/Drawer.styles.ts
@@ -69,16 +69,8 @@ export default tv({
   },
   variants: {
     shape: {
-      rounded: {
-        panel: [
-          'rounded-2xl'
-        ]
-      },
-      soft: {
-        panel: [
-          'rounded-lg'
-        ]
-      },
+      rounded: {},
+      soft: {},
       square: {
         panel: [
           'rounded-none'
@@ -212,6 +204,117 @@ export default tv({
       class: {
         panel: [
           'max-w-2xl'
+        ]
+      }
+    },
+    // shape soft & placement
+    {
+      placement: 'right',
+      shape: 'soft',
+      class: {
+        panel: [
+          'rounded-l-lg'
+        ]
+      }
+    },
+    {
+      placement: 'left',
+      shape: 'soft',
+      class: {
+        panel: [
+          'rounded-r-lg'
+        ]
+      }
+    },
+    {
+      placement: 'top',
+      shape: 'soft',
+      class: {
+        panel: [
+          'rounded-b-lg'
+        ]
+      }
+    },
+    {
+      placement: 'bottom',
+      shape: 'soft',
+      class: {
+        panel: [
+          'rounded-t-lg'
+        ]
+      }
+    },
+    // shape soft & placement
+    {
+      placement: 'right',
+      shape: 'soft',
+      class: {
+        panel: [
+          'rounded-l-lg'
+        ]
+      }
+    },
+    {
+      placement: 'left',
+      shape: 'soft',
+      class: {
+        panel: [
+          'rounded-r-lg'
+        ]
+      }
+    },
+    {
+      placement: 'top',
+      shape: 'soft',
+      class: {
+        panel: [
+          'rounded-b-lg'
+        ]
+      }
+    },
+    {
+      placement: 'bottom',
+      shape: 'soft',
+      class: {
+        panel: [
+          'rounded-t-lg'
+        ]
+      }
+    },
+    // shape rounded & placement
+    {
+      placement: 'right',
+      shape: 'rounded',
+      class: {
+        panel: [
+          'rounded-l-2xl'
+        ]
+      }
+    },
+    {
+      placement: 'left',
+      shape: 'rounded',
+      class: {
+        panel: [
+          'rounded-r-2xl'
+        ]
+      }
+    },
+    {
+      placement: 'top',
+      shape: 'rounded',
+      class: {
+        panel: [
+          'rounded-b-2xl'
+        ]
+      }
+    },
+    {
+      placement: 'bottom',
+      shape: 'rounded',
+      class: {
+        panel: [
+          'rounded-t-2xl'
         ]
       }
     }

--- a/packages/valko-ui-components/src/styles/Radio.styles.ts
+++ b/packages/valko-ui-components/src/styles/Radio.styles.ts
@@ -217,18 +217,18 @@ export default tv({
       disabled: false,
       class: {
         radio: [
-          'data-[checked=true]:bg-light-4',
-          'data-[checked=true]:border-light-4',
-          'data-[indeterminate=true]:border-light-4',
-          'data-[indeterminate=true]:bg-light-4',
-          'dark:data-[checked=true]:bg-dark-3',
-          'dark:data-[checked=true]:border-dark-3',
-          'dark:data-[indeterminate=true]:border-dark-3',
-          'dark:data-[indeterminate=true]:bg-dark-3'
+          'data-[checked=true]:bg-dark-4',
+          'data-[checked=true]:border-dark-4',
+          'data-[indeterminate=true]:border-dark-4',
+          'data-[indeterminate=true]:bg-dark-4',
+          'dark:data-[checked=true]:bg-light-3',
+          'dark:data-[checked=true]:border-light-3',
+          'dark:data-[indeterminate=true]:border-light-3',
+          'dark:data-[indeterminate=true]:bg-light-3'
         ],
         icon: [
-          'text-dark-1',
-          'dark:text-light-3'
+          'text-light-1',
+          'dark:text-dark-3'
         ]
       }
     },
@@ -324,10 +324,10 @@ export default tv({
       disabled: false,
       class: {
         radio: [
-          'data-[checked=true]:border-light-4',
-          'data-[indeterminate=true]:border-light-4',
-          'dark:data-[checked=true]:border-dark-3',
-          'dark:data-[indeterminate=true]:border-dark-3'
+          'data-[checked=true]:border-dark-4',
+          'data-[indeterminate=true]:border-dark-4',
+          'dark:data-[checked=true]:border-light-3',
+          'dark:data-[indeterminate=true]:border-light-3'
         ],
         icon: [
           'text-dark-1',
@@ -426,10 +426,10 @@ export default tv({
       disabled: false,
       class: {
         radio: [
-          'data-[checked=true]:bg-light-5/[.5]',
-          'data-[indeterminate=true]:bg-light-5/[.5]',
-          'dark:data-[checked=true]:bg-dark-5/[.5]',
-          'dark:data-[indeterminate=true]:bg-dark-5/[.5]'
+          'data-[checked=true]:bg-dark-5/[.5]',
+          'data-[indeterminate=true]:bg-dark-5/[.5]',
+          'dark:data-[checked=true]:bg-light-5/[.5]',
+          'dark:data-[indeterminate=true]:bg-light-5/[.5]'
         ],
         icon: [
           'text-dark-1',

--- a/packages/valko-ui-components/src/styles/Switch.styles.ts
+++ b/packages/valko-ui-components/src/styles/Switch.styles.ts
@@ -226,10 +226,14 @@ export default tv({
       disabled: false,
       class: {
         switch: [
-          'data-[active=true]:bg-light-5',
-          'data-[active=true]:border-light-5',
-          'dark:data-[active=true]:bg-dark-3',
-          'dark:data-[active=true]:border-dark-3'
+          'data-[active=true]:bg-dark-5',
+          'data-[active=true]:border-dark-5',
+          'dark:data-[active=true]:bg-light-3',
+          'dark:data-[active=true]:border-light-3'
+        ],
+        thumb: [
+          'bg-light-2',
+          'dark:bg-dark-3'
         ]
       }
     },
@@ -307,12 +311,12 @@ export default tv({
       disabled: false,
       class: {
         switch: [
-          'data-[active=true]:border-light-4',
-          'dark:data-[active=true]:border-dark-3'
+          'data-[active=true]:border-dark-4',
+          'dark:data-[active=true]:border-light-3'
         ],
         thumb: [
-          'data-[selected=true]:bg-light-4',
-          'dark:data-[selected=true]:bg-dark-3'
+          'data-[selected=true]:bg-dark-4',
+          'dark:data-[selected=true]:bg-light-3'
         ]
       }
     },
@@ -398,12 +402,12 @@ export default tv({
       disabled: false,
       class: {
         switch: [
-          'data-[active=true]:bg-light-5/[.4]',
-          'dark:data-[active=true]:bg-dark-2/[.4]'
+          'data-[active=true]:bg-dark-5/[.4]',
+          'dark:data-[active=true]:bg-light-2/[.4]'
         ],
         thumb: [
-          'data-[selected=true]:bg-light-5/[.5]',
-          'dark:data-[selected=true]:bg-dark-2/[.5]'
+          'data-[selected=true]:bg-dark-5/[.5]',
+          'dark:data-[selected=true]:bg-light-2/[.5]'
         ]
       }
     },

--- a/packages/valko-ui-docs/src/pages/docs/layout/DrawerPage.vue
+++ b/packages/valko-ui-docs/src/pages/docs/layout/DrawerPage.vue
@@ -83,7 +83,7 @@ const drawerProps = [
   {
     prop: 'closable',
     required: false,
-    description: 'Displays a close button on the Drawer',
+    description: 'Displays a close button on the Drawer and allows to close it by clicking outside or pressing esc',
     values: 'true, false',
     default: 'true'
   },
@@ -123,7 +123,7 @@ const toggleDrawer = (drawerId: string) => {
 <template>
   <doc-section
     title="Drawer"
-    description="A customizable drawer component that opens from any side of the screen, with options for shape, backdrop, and close button."
+    description="A versatile sliding drawer component that can appear from any side of the viewport, with options for shape, size, backdrop, placement, title, shadow, and optional close functionality."
   >
     <template #playground-view>
       <vk-button @click="toggleDrawer('playground-drawer')">

--- a/packages/valko-ui-docs/src/pages/docs/layout/ModalPage.vue
+++ b/packages/valko-ui-docs/src/pages/docs/layout/ModalPage.vue
@@ -80,7 +80,7 @@ const modalProps = [
   {
     prop: 'closable',
     required: false,
-    description: 'Displays a close button on the Modal',
+    description: 'Displays a close button on the Modal and allows to close it by clicking outside or pressing esc',
     values: 'true, false',
     default: 'true'
   },

--- a/packages/valko-ui-docs/src/pages/docs/ui/CardPage.vue
+++ b/packages/valko-ui-docs/src/pages/docs/ui/CardPage.vue
@@ -413,7 +413,7 @@ const randomImage = () => useNotification({ text: 'Loading random image...' })
           title="Card Props"
           gap
         >
-          <vk-data-table
+          <vk-table
             :headers="propHeaders"
             :data="cardProps"
           />
@@ -423,7 +423,7 @@ const randomImage = () => useNotification({ text: 'Loading random image...' })
           title="Card Emits"
           gap
         >
-          <vk-data-table
+          <vk-table
             :headers="emitHeaders"
             :data="cardEmits"
           />
@@ -433,7 +433,7 @@ const randomImage = () => useNotification({ text: 'Loading random image...' })
           title="Card Slots"
           gap
         >
-          <vk-data-table
+          <vk-table
             :headers="slotHeaders"
             :data="cardSlots"
           />
@@ -443,7 +443,7 @@ const randomImage = () => useNotification({ text: 'Loading random image...' })
           title="Card Image Props"
           gap
         >
-          <vk-data-table
+          <vk-table
             :headers="propHeaders"
             :data="cardImageProps"
           />


### PR DESCRIPTION
## Components
### Drawer
- Add shape and size in description
- Add a width option that replace the defaults sizes
- Closable prop should not allow to close the drawer with the esc key or by clicking outside
- Shapes should only affect the exterior corners of the component

### Modal
- Closable prop should not allow to close the  modal with the esc key or by clicking outside

### Radio
- Invert the colors in the neutral color prop

### Checkbox
- Invert the colors in the neutral color prop

### Switch
- Invert background color in the neutral color prop

## Docs
### Card Page
- Use Table component insted of DataTable in the API section

### Extra
- Check that all pages are using Table component in the API section instead of DataTable