### PR TITLE
fix(vui-135): update reduce function to ensure items without a group are assigned to the default group.

### DIFF
--- a/.changeset/dull-adults-destroy.md
+++ b/.changeset/dull-adults-destroy.md
@@ -1,0 +1,7 @@
+---
+"@valko-ui/components": patch
+---
+
+**Menu:**
+
+- Updated reduce function to ensure items without a `group` are assigned to the `default` group.

--- a/packages/valko-ui-components/src/components/Menu.vue
+++ b/packages/valko-ui-components/src/components/Menu.vue
@@ -20,6 +20,7 @@ const classes = useStyle<MenuProps, SlotStyles>(props, styles)
 
 const groups = props.items.reduce((acc: Set<string>, item: MenuItem) => {
   if (item.group) acc.add(item.group)
+  else acc.add('default')
   return acc
 }, new Set(['default']) as Set<string>)
 


### PR DESCRIPTION
The menu component previously required a group declaration on each item, which could be inconvenient if items were not grouped. This update ensures that items without a group are automatically assigned to a 'default' group. Additionally, the group title is hidden when the group is 'default' to avoid unnecessary UI elements.