### PR TITLE
fix(vui-149): UI/UX and Documentation Polish – Components, Styling & Behavior Improvements.

### DIFF
--- a/packages/valko-ui-components/vite.config.ts
+++ b/packages/valko-ui-components/vite.config.ts
@@ -28,9 +28,11 @@ export default defineConfig({
       tsconfigOverride: {
         compilerOptions: {
           outDir: 'dist',
-          sourceMap: false,
+          sourceMap: true,
           declaration: false,
-          declarationMap: false
+          declarationMap: false,
+          noEmitOnError: false,
+          noEmit: false
         }
       },
       exclude: ['vite.config.ts']
@@ -38,11 +40,11 @@ export default defineConfig({
     copy({
       hook: 'writeBundle',
       targets: [
-        { src: 'src/components/*.vue', dest: 'dist/components' },
-        { src: 'src/composables/*.ts', dest: 'dist/composables' },
-        { src: 'src/styles/*.ts', dest: 'dist/styles' },
-        { src: 'src/types/*.ts', dest: 'dist/types' },
-        { src: 'src/img/*', dest: 'dist/img' }
+        { src: 'src/components/*.vue', dest: 'dist/components', ignore: ['**/*.map'] },
+        { src: 'src/composables/*.ts', dest: 'dist/composables', ignore: ['**/*.map'] },
+        { src: 'src/styles/*.ts', dest: 'dist/styles', ignore: ['**/*.map'] },
+        { src: 'src/types/*.ts', dest: 'dist/types', ignore: ['**/*.map'] },
+        { src: 'src/img/*', dest: 'dist/img', ignore: ['**/*.map'] }
       ]
     })
   ],
@@ -54,12 +56,14 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       reporter: ['text', 'html'],
+      enabled: true,
       reportsDirectory: '../coverage',
       exclude: ['exports', 'scripts', 'types', 'img', '**/__mocks__', '**/__test__']
     }
   },
   build: {
     cssCodeSplit: true,
+    sourcemap: false,
     lib: {
       entry: 'src/index.ts',
       name: 'ValkoUI',

--- a/packages/valko-ui-docs/components/CodeBlock/CodeBlock.vue
+++ b/packages/valko-ui-docs/components/CodeBlock/CodeBlock.vue
@@ -54,13 +54,13 @@ const copyToClipboard = async () => {
 </script>
 
 <template>
-  <div class="relative group w-full p-5 bg-surface-container rounded-lg">
+  <div class="relative group w-full p-5 bg-surface-container rounded">
     <vk-button
       variant="link"
       shape="rounded"
       color="secondary"
       condensed
-      class="size-5 absolute top-2 right-2 opacity-0 group-hover:opacity-100 transition-opacity"
+      class="size-5 absolute top-0 right-0 opacity-0 group-hover:opacity-100 transition-opacity"
       @click="copyToClipboard"
     >
       <vk-icon

--- a/packages/valko-ui-docs/components/DocSection/DocSection.vue
+++ b/packages/valko-ui-docs/components/DocSection/DocSection.vue
@@ -55,7 +55,7 @@ const classes = useStyle<DocSectionProps, SlotStyles>(props, styles)
         API
       </h2>
       <hr :class="classes.divider">
-      <div class="flex flex-col justify-around items-start gap-2 text-xl">
+      <div class="flex flex-col justify-around items-start gap-4 text-xl">
         <slot name="api" />
       </div>
     </section>

--- a/packages/valko-ui-docs/components/ExampleSection/ExampleSection.vue
+++ b/packages/valko-ui-docs/components/ExampleSection/ExampleSection.vue
@@ -20,7 +20,7 @@ const parsedStyles = useStyle<ExampleSectionProps>(props, styles)
 
 <template>
   <section class="w-full mt-10">
-    <h3 class="text-xl pl-3 pt-3 bg-light-200 dark:bg-dark-800 rounded-t-lg">
+    <h3 class="text-xl pl-3 pt-3 bg-surface-container-lowest rounded-t-lg">
       {{ props.title }}
     </h3>
     <vk-tabs
@@ -35,7 +35,7 @@ const parsedStyles = useStyle<ExampleSectionProps>(props, styles)
       </template>
 
       <template #code>
-        <div class="p-4 bg-light-300 dark:bg-dark-950/[.5] rounded-b-lg">
+        <div class="p-4 bg-surface-container-lowest r rounded-b-lg">
           <slot name="code" />
         </div>
       </template>

--- a/packages/valko-ui-docs/components/SiteLinks/SiteLinks.vue
+++ b/packages/valko-ui-docs/components/SiteLinks/SiteLinks.vue
@@ -14,6 +14,7 @@ const route = useRoute()
               variant="link"
               :color="route.fullPath === '/' ? 'primary' : 'surface'"
               size="sm"
+              class="font-bold"
             >
               Home
             </vk-button>
@@ -25,6 +26,7 @@ const route = useRoute()
               variant="link"
               :color="route.fullPath.startsWith('/docs') ? 'primary' : 'surface'"
               size="sm"
+              class="font-bold"
             >
               Documentation
             </vk-button>
@@ -36,6 +38,7 @@ const route = useRoute()
               variant="link"
               :color="route.fullPath.startsWith('/templates') ? 'primary' : 'surface'"
               size="sm"
+              class="font-bold"
             >
               Templates
             </vk-button>

--- a/packages/valko-ui-docs/pages/docs/forms/checkbox.vue
+++ b/packages/valko-ui-docs/pages/docs/forms/checkbox.vue
@@ -20,29 +20,17 @@ const form = reactive<CheckboxProps>({
 
 const indeterminateRef = ref(false)
 
-const checkboxStates = reactive<Record<string, boolean>>({
-  primary: true,
-  secondary: true,
-  accent: true,
-  warning: true,
-  negative: true,
-  positive: true,
-  filled: true,
-  outlined: true,
-  ghost: true,
-  rounded: true,
-  square: true,
-  soft: true,
-  xs: true,
-  sm: true,
-  md: true,
-  lg: true,
-  indeterminate: true,
-  right: true,
-  left: true,
-  readonly: true,
-  disabled: true
-})
+const checkboxStates = reactive(
+  Object.fromEntries([
+    ...colorOptions.general,
+    ...variantOptions.general,
+    ...shapeOptions.general,
+    ...sizeOptions.general,
+    ...position,
+    { value: 'readonly' },
+    { value: 'indeterminate' }
+  ].map(opt => [opt.value, true]))
+)
 
 const apiData: TableItem[] = [
   {

--- a/packages/valko-ui-docs/pages/docs/forms/radio.vue
+++ b/packages/valko-ui-docs/pages/docs/forms/radio.vue
@@ -19,9 +19,15 @@ const position: SelectOption<LabelPosition>[] = [
   { value: 'left', label:'Left' }
 ]
 
-const radioStates = reactive<Record<string, string>>({
-  'readonly-radio': 'readonly'
-})
+const radioStates = reactive(
+  Object.fromEntries([
+    ...colorOptions.general,
+    ...variantOptions.general,
+    ...shapeOptions.general,
+    ...sizeOptions.general,
+    { value: 'readonly' }
+  ].map(opt => [opt.value, opt.value]))
+)
 
 const apiData: TableItem[] = [
   {
@@ -221,8 +227,8 @@ const generateSnippet = snippetGeneratorFactory('vk-radio')
         <vk-radio
           v-for="color in colorOptions.general"
           :key="color.value"
-          v-model="radioStates['color-radio-group']"
-          name="color-radio-group"
+          v-model="radioStates[color.value]"
+          :name="color.value"
           :color="color.value"
           :label="color.label"
           :value="color.value"
@@ -240,8 +246,8 @@ const generateSnippet = snippetGeneratorFactory('vk-radio')
         <vk-radio
           v-for="variant in variantOptions.general"
           :key="variant.value"
-          v-model="radioStates['variant-radio-group']"
-          name="variant-radio-group"
+          v-model="radioStates[variant.value]"
+          :name="variant.value"
           :variant="variant.value"
           :label="variant.label"
           :value="variant.value"
@@ -259,8 +265,8 @@ const generateSnippet = snippetGeneratorFactory('vk-radio')
         <vk-radio
           v-for="shape in shapeOptions.general"
           :key="shape.value"
-          v-model="radioStates['shape-radio-group']"
-          name="shape-radio-group"
+          v-model="radioStates[shape.value]"
+          :name="shape.value"
           :shape="shape.value"
           :label="shape.label"
           :value="shape.value"
@@ -278,8 +284,8 @@ const generateSnippet = snippetGeneratorFactory('vk-radio')
         <vk-radio
           v-for="size in sizeOptions.general"
           :key="size.value"
-          v-model="radioStates['size-radio-group']"
-          name="size-radio-group"
+          v-model="radioStates[size.value]"
+          :name="size.value"
           :size="size.value"
           :label="size.label"
           :value="size.value"
@@ -303,8 +309,8 @@ const generateSnippet = snippetGeneratorFactory('vk-radio')
 
       <example-section title="Readonly">
         <vk-radio
-          v-model="radioStates['readonly-radio']"
-          name="readonly-radio"
+          v-model="radioStates['readonly']"
+          name="readonly"
           value="readonly"
           readonly
           label="Readonly"

--- a/packages/valko-ui-docs/pages/docs/forms/switch.vue
+++ b/packages/valko-ui-docs/pages/docs/forms/switch.vue
@@ -18,7 +18,16 @@ const position: SelectOption<LabelPosition>[] = [
   { value: 'left', label: 'Left' }
 ]
 
-const exampleSectionModel = reactive<Record<string, boolean>>({ readonly: true })
+const switchStates = reactive(
+  Object.fromEntries([
+    ...colorOptions.general,
+    ...variantOptions.general,
+    ...shapeOptions.general,
+    ...sizeOptions.general,
+    ...position,
+    { value: 'readonly' }
+  ].map(opt => [opt.value, true]))
+)
 
 const apiData: TableItem[] = [
   {
@@ -181,7 +190,7 @@ const generateSnippet = snippetGeneratorFactory('vk-switch')
         <vk-switch
           v-for="color in colorOptions.general"
           :key="color.value"
-          v-model="exampleSectionModel[color.value]"
+          v-model="switchStates[color.value]"
           :color="color.value"
           :label="color.label"
         />
@@ -198,7 +207,7 @@ const generateSnippet = snippetGeneratorFactory('vk-switch')
         <vk-switch
           v-for="variant in variantOptions.general"
           :key="variant.value"
-          v-model="exampleSectionModel[variant.value]"
+          v-model="switchStates[variant.value]"
           :variant="variant.value"
           :label="variant.label"
         />
@@ -215,7 +224,7 @@ const generateSnippet = snippetGeneratorFactory('vk-switch')
         <vk-switch
           v-for="shape in shapeOptions.general"
           :key="shape.value"
-          v-model="exampleSectionModel[shape.value]"
+          v-model="switchStates[shape.value]"
           :shape="shape.value"
           :label="shape.label"
         />
@@ -232,7 +241,7 @@ const generateSnippet = snippetGeneratorFactory('vk-switch')
         <vk-switch
           v-for="size in sizeOptions.general"
           :key="size.value"
-          v-model="exampleSectionModel[size.value]"
+          v-model="switchStates[size.value]"
           :size="size.value"
           :label="size.label"
         />
@@ -252,7 +261,7 @@ const generateSnippet = snippetGeneratorFactory('vk-switch')
 
       <example-section title="Readonly">
         <vk-switch
-          v-model="exampleSectionModel['readonly']"
+          v-model="switchStates['readonly']"
           readonly
         />
 
@@ -268,7 +277,7 @@ const generateSnippet = snippetGeneratorFactory('vk-switch')
         <vk-switch
           v-for="pos in position"
           :key="pos.value"
-          v-model="exampleSectionModel[pos.value]"
+          v-model="switchStates[pos.value]"
           :label-position="pos.value"
           :label="pos.label"
         />

--- a/packages/valko-ui-docs/pages/index.vue
+++ b/packages/valko-ui-docs/pages/index.vue
@@ -83,7 +83,7 @@ const toggleMenu = () => menuOpen.value = !menuOpen.value
     <div class="flex flex-col md:flex-row gap-2 max-w-full items-stretch">
       <code-block
         code="npm install @valko-ui/components"
-        class="bg-light-200 dark:bg-dark-800 rounded-lg md:order-2"
+        class="md:order-2"
       />
       <nuxt-link to="/docs">
         <vk-button class="h-full gap-2 items-center">


### PR DESCRIPTION
[VUI-149](https://github.com/ValkoDevs/valko-ui/issues/149):

## Documentation:
 - [x] Add consistent spacing between tables and section titles across all API documentation pages.

 - [x] Ensure all switches in the documentation are turned on by default to better reflect typical usage.

 - [x] In the example sections, decouple radio buttons so they are no longer grouped—this will allow each to be set as checked independently by default.

 - [x] Make the top navigation menu items bold to distinguish them from general buttons (only the top menu, not all buttons).

## Components / Styling:
  - [ ] Revisit the thumb color for Range sliders in dark mode to ensure sufficient contrast and consistency.

  - [ ] Add surface color option for Calendar.

  - [ ] Improve disabled button colors—they currently lack appropriate contrast or clarity.

  - [ ] Address issue where the Tabs panel prevents content from expanding beyond its container.

  - [ ] Investigate and fix cursor position issues in Tabs when props change dynamically—cursor sometimes fails to update correctly.

  - [ ] Ensure buttons in the Time component are styled and positioned correctly.
  
 - [ ] In Navbar component remove elevation (box-shadow) from the sticky navbar by default. Introduce an elevated option to allow setting it to elevation level 2 (el2) when needed. 
 
 - [ ] Ensure notifications use the surface-inverse color to maintain legibility. 

 - [ ] Fix layout issues in CodeBlock component: the copy button is misaligned (on the wrong side) and padding appears incorrect.

## Testing:
  - [x] Fix test coverage reporting to accurately reflect actual coverage.