### PR TITLE
fix(vui-181): fix select icon slot handling.

### DIFF
--- a/.changeset/bitter-lions-rule.md
+++ b/.changeset/bitter-lions-rule.md
@@ -1,0 +1,27 @@
+---
+"@valko-ui/components": patch
+"@valko-ui/docs": patch
+---
+
+## Valko-UI Components
+
+### Components
+
+- Added `iconClickFocus` prop to `Input` (default: true), allowing users to control whether icon clicks focus the input field.
+- Improved event forwarding in `Select` by forwarding both left and right icon slots and their respective emits from `Input`.
+- Chevron icon in `Select` is now rendered independently and no longer occupies the right icon slot of `Input`.
+
+### Styles
+
+- Introduced `rightIcon` and `clearIcon` style slots in `Select.styles.ts` to enable custom padding and spacing for icons.
+- Renamed the `icon` slot to `chevronIcon` in `Select.styles.ts` for clarity and consistency.
+
+---
+
+## Valko-UI Docs
+
+### Components
+- Documented the `SelectOption` interface in the Select API section.
+- Added documentation for left and right icon emits in the Select API section.
+- Included documentation for left and right icon slots in the Select API section.
+- Added the `iconClickFocus` prop to the Input API documentation.

--- a/.changeset/bitter-lions-rule.md
+++ b/.changeset/bitter-lions-rule.md
@@ -9,12 +9,12 @@
 
 - **Input:** 
   - Added `disableIconClickFocus` prop to `Input` (default: false), allowing users to control whether icon clicks focus the input field.
+  - Added `forceClearable` prop to `Input` (default: false), allowing the clear icon to work even when the input is readonly.
   - Added `suffix-icon` slot, this is commonly used as a complement icon, for (eg. Select component uses it for the chevron.)
   - Added `suffixIconClick` emit allowing user to trigger custom behavior on icon click.
 - **Select:** 
   - Improved event forwarding in `Select` by forwarding both left and right icon slots and their respective emits from `Input`.
   - Chevron icon in `Select` has now its own dedicated slot and no longer occupies the right icon slot of `Input`.
-  - Added `disableIconClickFocus` prop to `Select` (default: true), allowing users to control wheter icon clicks focus the input field.
   - Added `suffix-icon` slot, this defaults to the chevron icon, we're forwarding `is-open` and `toggleDropdown` allowing it to be customizable and dynamic.
 
 ### Styles
@@ -27,6 +27,11 @@
 
 ### Tests
 
+- **Input:**
+  - Added tests for `suffix-icon` slot rendering.
+  - Added test for `suffixIconClick` emit.
+  - Added tests for `disableIconClickFocus` focus behavior.
+  - Added tests for `forceClearable` prop (readonly guard, disabled guard).
 - **Select:**
   - Added tests for `left-icon`, `right-icon`, and `suffix-icon` slot rendering and forwarding.
   - Added tests for `suffix-icon` scoped slot props (`is-open`, `toggle-dropdown`).
@@ -48,7 +53,6 @@
   - Documented the `SelectOption` interface in the API section.
   - Added documentation for left, right, suffix icon emits in the API section.
   - Included documentation for left, right, and suffix icon slots in the API section.
-  - Added the `disableIconClickFocus` prop to the API documentation.
   - Added the `suffixIcon` style slot to the API documentation.
   - Removed stale `rounded`, `iconLeft`, and `iconRight` props from API docs.
   - Fixed `shape` description from "Button" to "Select".

--- a/.changeset/bitter-lions-rule.md
+++ b/.changeset/bitter-lions-rule.md
@@ -1,5 +1,5 @@
 ---
-"@valko-ui/components": patch
+"@valko-ui/components": minor
 "@valko-ui/docs": patch
 ---
 

--- a/.changeset/bitter-lions-rule.md
+++ b/.changeset/bitter-lions-rule.md
@@ -13,9 +13,9 @@
   - Added `suffixIconClick` emit allowing user to trigger custom behavior on icon click.
 - **Select:** 
   - Improved event forwarding in `Select` by forwarding both left and right icon slots and their respective emits from `Input`.
-  - Chevron icon in `Select` has now it's own dedicated slot and no longer occupies the right icon slot of `Input`.
+  - Chevron icon in `Select` has now its own dedicated slot and no longer occupies the right icon slot of `Input`.
   - Added `disableIconClickFocus` prop to `Select` (default: true), allowing users to control wheter icon clicks focus the input field.
-  - Added `suffix-icon` slot, this defaults to the chevron icon, we're fowarding `is-open` and `toggleDropdown` allowing it to be customizable and dynamic.
+  - Added `suffix-icon` slot, this defaults to the chevron icon, we're forwarding `is-open` and `toggleDropdown` allowing it to be customizable and dynamic.
 
 ### Styles
 
@@ -24,6 +24,13 @@
   - Replaced per-icon boolean data attributes (`data-right-icon`, `data-clear-icon`, `data-suffix-icon`, `data-chevron-icons`) on the `<input>` element with a single numeric `data-right-icon-count` attribute for padding calculation.
   - Added `rightIconsContainer` style slot for the right-side icons wrapper.
   - All right-side icons (clear, right, suffix, chevrons) are now rendered inside a single flex container with consistent gap-based spacing per size.
+
+### Tests
+
+- **Select:**
+  - Added tests for `left-icon`, `right-icon`, and `suffix-icon` slot rendering and forwarding.
+  - Added tests for `suffix-icon` scoped slot props (`is-open`, `toggle-dropdown`).
+  - Added tests for `leftIconClick`, `rightIconClick`, and `suffixIconClick` event forwarding.
 
 ---
 

--- a/.changeset/bitter-lions-rule.md
+++ b/.changeset/bitter-lions-rule.md
@@ -3,25 +3,46 @@
 "@valko-ui/docs": patch
 ---
 
-## Valko-UI Components
+## Valko-UI Components:
 
 ### Components
 
-- Added `iconClickFocus` prop to `Input` (default: true), allowing users to control whether icon clicks focus the input field.
-- Improved event forwarding in `Select` by forwarding both left and right icon slots and their respective emits from `Input`.
-- Chevron icon in `Select` is now rendered independently and no longer occupies the right icon slot of `Input`.
+- **Input:** 
+  - Added `disableIconClickFocus` prop to `Input` (default: false), allowing users to control whether icon clicks focus the input field.
+  - Added `suffix-icon` slot, this is commonly used as a complement icon, for (eg. Select component uses it for the chevron.)
+  - Added `suffixIconClick` emit allowing user to trigger custom behavior on icon click.
+- **Select:** 
+  - Improved event forwarding in `Select` by forwarding both left and right icon slots and their respective emits from `Input`.
+  - Chevron icon in `Select` has now it's own dedicated slot and no longer occupies the right icon slot of `Input`.
+  - Added `disableIconClickFocus` prop to `Select` (default: true), allowing users to control wheter icon clicks focus the input field.
+  - Added `suffix-icon` slot, this defaults to the chevron icon, we're fowarding `is-open` and `toggleDropdown` allowing it to be customizable and dynamic.
 
 ### Styles
 
-- Introduced `rightIcon` and `clearIcon` style slots in `Select.styles.ts` to enable custom padding and spacing for icons.
-- Renamed the `icon` slot to `chevronIcon` in `Select.styles.ts` for clarity and consistency.
+- **Input:**
+  - Replaced individual icon positioning (`right-N` with data-attribute compound variants) with a flex-based `rightIconsContainer` that manages spacing via `gap`.
+  - Replaced per-icon boolean data attributes (`data-right-icon`, `data-clear-icon`, `data-suffix-icon`, `data-chevron-icons`) on the `<input>` element with a single numeric `data-right-icon-count` attribute for padding calculation.
+  - Added `rightIconsContainer` style slot for the right-side icons wrapper.
+  - All right-side icons (clear, right, suffix, chevrons) are now rendered inside a single flex container with consistent gap-based spacing per size.
 
 ---
 
-## Valko-UI Docs
+## Valko-UI Docs:
 
-### Components
-- Documented the `SelectOption` interface in the Select API section.
-- Added documentation for left and right icon emits in the Select API section.
-- Included documentation for left and right icon slots in the Select API section.
-- Added the `iconClickFocus` prop to the Input API documentation.
+### Pages
+- **Input:**
+  - Added the `disableIconClickFocus` prop to the API documentation.
+  - Added missing `clearable` prop to the API documentation.
+  - Removed stale `rounded` prop from API docs (replaced by `shape`).
+  - Fixed `cursor` values from `cursor | text` to `pointer, text`.
+  - Fixed incorrect default values for `modelValue`, `label`, and `helpertext`.
+  - Added `@suffix-icon-click` listener to playground.
+- **Select:**
+  - Documented the `SelectOption` interface in the API section.
+  - Added documentation for left, right, suffix icon emits in the API section.
+  - Included documentation for left, right, and suffix icon slots in the API section.
+  - Added the `disableIconClickFocus` prop to the API documentation.
+  - Added the `suffixIcon` style slot to the API documentation.
+  - Removed stale `rounded`, `iconLeft`, and `iconRight` props from API docs.
+  - Fixed `shape` description from "Button" to "Select".
+  - Fixed incorrect default values for `modelValue`, `label`, and `helpertext`.

--- a/.changeset/bitter-lions-rule.md
+++ b/.changeset/bitter-lions-rule.md
@@ -10,32 +10,17 @@
 - **Input:** 
   - Added `disableIconClickFocus` prop to `Input` (default: false), allowing users to control whether icon clicks focus the input field.
   - Added `forceClearable` prop to `Input` (default: false), allowing the clear icon to work even when the input is readonly.
-  - Added `suffix-icon` slot, this is commonly used as a complement icon, for (eg. Select component uses it for the chevron.)
-  - Added `suffixIconClick` emit allowing user to trigger custom behavior on icon click.
+  - Fixed guard clauses in `clearInput` and `handleIconClick` to allow the expected events to be emitted.
 - **Select:** 
-  - Improved event forwarding in `Select` by forwarding both left and right icon slots and their respective emits from `Input`.
-  - Chevron icon in `Select` has now its own dedicated slot and no longer occupies the right icon slot of `Input`.
-  - Added `suffix-icon` slot, this defaults to the chevron icon, we're forwarding `is-open` and `toggleDropdown` allowing it to be customizable and dynamic.
-
-### Styles
-
-- **Input:**
-  - Replaced individual icon positioning (`right-N` with data-attribute compound variants) with a flex-based `rightIconsContainer` that manages spacing via `gap`.
-  - Replaced per-icon boolean data attributes (`data-right-icon`, `data-clear-icon`, `data-suffix-icon`, `data-chevron-icons`) on the `<input>` element with a single numeric `data-right-icon-count` attribute for padding calculation.
-  - Added `rightIconsContainer` style slot for the right-side icons wrapper.
-  - All right-side icons (clear, right, suffix, chevrons) are now rendered inside a single flex container with consistent gap-based spacing per size.
+  - Fixed forwarding of the `left-icon` slot and `leftIconClick` event.
+  - Forwarded the `disableIconClickFocus` prop to the underlying `Input`.
 
 ### Tests
 
 - **Input:**
-  - Added tests for `suffix-icon` slot rendering.
-  - Added test for `suffixIconClick` emit.
-  - Added tests for `disableIconClickFocus` focus behavior.
-  - Added tests for `forceClearable` prop (readonly guard, disabled guard).
+  - Added tests for the `forceClearable` prop.
 - **Select:**
-  - Added tests for `left-icon`, `right-icon`, and `suffix-icon` slot rendering and forwarding.
-  - Added tests for `suffix-icon` scoped slot props (`is-open`, `toggle-dropdown`).
-  - Added tests for `leftIconClick`, `rightIconClick`, and `suffixIconClick` event forwarding.
+  - Added tests for the `left-icon` slot and `leftIconClick` event.
 
 ---
 
@@ -48,12 +33,11 @@
   - Removed stale `rounded` prop from API docs (replaced by `shape`).
   - Fixed `cursor` values from `cursor | text` to `pointer, text`.
   - Fixed incorrect default values for `modelValue`, `label`, and `helpertext`.
-  - Added `@suffix-icon-click` listener to playground.
 - **Select:**
   - Documented the `SelectOption` interface in the API section.
-  - Added documentation for left, right, suffix icon emits in the API section.
-  - Included documentation for left, right, and suffix icon slots in the API section.
-  - Added the `suffixIcon` style slot to the API documentation.
+  - Added documentation for the `leftIconClick` event in the API section.
+  - Added documentation for the `left-icon` slot in the API section.
   - Removed stale `rounded`, `iconLeft`, and `iconRight` props from API docs.
   - Fixed `shape` description from "Button" to "Select".
   - Fixed incorrect default values for `modelValue`, `label`, and `helpertext`.
+  - Added the `disableIconClickFocus` prop to the API documentation.

--- a/packages/valko-ui-components/src/__test__/Input.spec.ts
+++ b/packages/valko-ui-components/src/__test__/Input.spec.ts
@@ -988,6 +988,22 @@ describe('Input component', () => {
 
       expect(wrapper.find('.right-icon').exists()).toBe(false)
     })
+
+    it('should render suffix-icon when slot suffix-icon is set', () => {
+      wrapper = mount(VkInput, {
+        slots: {
+          'suffix-icon': '<i class="ti ti-chevron-down"></i>'
+        }
+      })
+
+      expect(wrapper.find('i.ti.ti-chevron-down').exists()).toBe(true)
+    })
+
+    it('should not render suffix-icon when not provided', () => {
+      const wrapper = mount(VkInput)
+
+      expect(wrapper.find('.suffix-icon').exists()).toBe(false)
+    })
   })
 
   describe('Emits', () => {
@@ -1065,6 +1081,61 @@ describe('Input component', () => {
       await wrapper.find('i.ti.ti-home').trigger('click')
 
       expect(wrapper.emitted()).toHaveProperty('rightIconClick')
+    })
+
+    it('should emit suffixIconClick when slot suffix-icon is clicked', async () => {
+      wrapper = mount(VkInput, {
+        slots: {
+          'suffix-icon': '<i class="ti ti-chevron-down"></i>'
+        }
+      })
+
+      await wrapper.find('i.ti.ti-chevron-down').trigger('click')
+
+      expect(wrapper.emitted()).toHaveProperty('suffixIconClick')
+    })
+
+    it('should not emit suffixIconClick when disabled', async () => {
+      wrapper = mount(VkInput, {
+        props: { disabled: true },
+        slots: {
+          'suffix-icon': '<i class="ti ti-chevron-down"></i>'
+        }
+      })
+
+      await wrapper.find('i.ti.ti-chevron-down').trigger('click')
+
+      expect(wrapper.emitted()).not.toHaveProperty('suffixIconClick')
+    })
+
+    it('should focus input after icon click when disableIconClickFocus is false', async () => {
+      wrapper = mount(VkInput, {
+        props: { disableIconClickFocus: false },
+        slots: {
+          'suffix-icon': '<i class="ti ti-chevron-down"></i>'
+        },
+        attachTo: document.body
+      })
+
+      await wrapper.find('i.ti.ti-chevron-down').trigger('click')
+
+      expect(wrapper.find('.vk-input__input').element).toBe(document.activeElement)
+      wrapper.unmount()
+    })
+
+    it('should not focus input after icon click when disableIconClickFocus is true', async () => {
+      wrapper = mount(VkInput, {
+        props: { disableIconClickFocus: true },
+        slots: {
+          'suffix-icon': '<i class="ti ti-chevron-down"></i>'
+        },
+        attachTo: document.body
+      })
+
+      await wrapper.find('i.ti.ti-chevron-down').trigger('click')
+
+      expect(wrapper.find('.vk-input__input').element).not.toBe(document.activeElement)
+      wrapper.unmount()
     })
 
     it('Should emit clear when the clear icon is clickled', () => {

--- a/packages/valko-ui-components/src/__test__/Input.spec.ts
+++ b/packages/valko-ui-components/src/__test__/Input.spec.ts
@@ -1002,7 +1002,7 @@ describe('Input component', () => {
     it('should not render suffix-icon when not provided', () => {
       const wrapper = mount(VkInput)
 
-      expect(wrapper.find('.suffix-icon').exists()).toBe(false)
+      expect(wrapper.find('.vk-input__right-icons').exists()).toBe(false)
     })
   })
 

--- a/packages/valko-ui-components/src/__test__/Input.spec.ts
+++ b/packages/valko-ui-components/src/__test__/Input.spec.ts
@@ -1035,22 +1035,6 @@ describe('Input component', () => {
 
       expect(wrapper.find('.right-icon').exists()).toBe(false)
     })
-
-    it('should render suffix-icon when slot suffix-icon is set', () => {
-      wrapper = mount(VkInput, {
-        slots: {
-          'suffix-icon': '<i class="ti ti-chevron-down"></i>'
-        }
-      })
-
-      expect(wrapper.find('i.ti.ti-chevron-down').exists()).toBe(true)
-    })
-
-    it('should not render suffix-icon when not provided', () => {
-      const wrapper = mount(VkInput)
-
-      expect(wrapper.find('.vk-input__right-icons').exists()).toBe(false)
-    })
   })
 
   describe('Emits', () => {
@@ -1128,61 +1112,6 @@ describe('Input component', () => {
       await wrapper.find('i.ti.ti-home').trigger('click')
 
       expect(wrapper.emitted()).toHaveProperty('rightIconClick')
-    })
-
-    it('should emit suffixIconClick when slot suffix-icon is clicked', async () => {
-      wrapper = mount(VkInput, {
-        slots: {
-          'suffix-icon': '<i class="ti ti-chevron-down"></i>'
-        }
-      })
-
-      await wrapper.find('i.ti.ti-chevron-down').trigger('click')
-
-      expect(wrapper.emitted()).toHaveProperty('suffixIconClick')
-    })
-
-    it('should not emit suffixIconClick when disabled', async () => {
-      wrapper = mount(VkInput, {
-        props: { disabled: true },
-        slots: {
-          'suffix-icon': '<i class="ti ti-chevron-down"></i>'
-        }
-      })
-
-      await wrapper.find('i.ti.ti-chevron-down').trigger('click')
-
-      expect(wrapper.emitted()).not.toHaveProperty('suffixIconClick')
-    })
-
-    it('should focus input after icon click when disableIconClickFocus is false', async () => {
-      wrapper = mount(VkInput, {
-        props: { disableIconClickFocus: false },
-        slots: {
-          'suffix-icon': '<i class="ti ti-chevron-down"></i>'
-        },
-        attachTo: document.body
-      })
-
-      await wrapper.find('i.ti.ti-chevron-down').trigger('click')
-
-      expect(wrapper.find('.vk-input__input').element).toBe(document.activeElement)
-      wrapper.unmount()
-    })
-
-    it('should not focus input after icon click when disableIconClickFocus is true', async () => {
-      wrapper = mount(VkInput, {
-        props: { disableIconClickFocus: true },
-        slots: {
-          'suffix-icon': '<i class="ti ti-chevron-down"></i>'
-        },
-        attachTo: document.body
-      })
-
-      await wrapper.find('i.ti.ti-chevron-down').trigger('click')
-
-      expect(wrapper.find('.vk-input__input').element).not.toBe(document.activeElement)
-      wrapper.unmount()
     })
 
     it('Should emit clear when the clear icon is clickled', () => {

--- a/packages/valko-ui-components/src/__test__/Input.spec.ts
+++ b/packages/valko-ui-components/src/__test__/Input.spec.ts
@@ -378,6 +378,53 @@ describe('Input component', () => {
       })
     })
 
+    describe('When forceClearable prop changes', () => {
+      it('should not clear the input when readonly and forceClearable is false', async () => {
+        wrapper = mount(VkInput, {
+          props: {
+            clearable: true,
+            readonly: true,
+            forceClearable: false,
+            modelValue: 'Hello World'
+          }
+        })
+
+        await wrapper.find('i.ti.ti-x').trigger('click')
+
+        expect(wrapper.emitted('update:modelValue')).toBeUndefined()
+      })
+
+      it('should clear the input when readonly and forceClearable is true', async () => {
+        wrapper = mount(VkInput, {
+          props: {
+            clearable: true,
+            readonly: true,
+            forceClearable: true,
+            modelValue: 'Hello World'
+          }
+        })
+
+        await wrapper.find('i.ti.ti-x').trigger('click')
+
+        expect(wrapper.emitted('update:modelValue')).toStrictEqual([['']])
+      })
+
+      it('should not clear the input when disabled even if forceClearable is true', async () => {
+        wrapper = mount(VkInput, {
+          props: {
+            clearable: true,
+            disabled: true,
+            forceClearable: true,
+            modelValue: 'Hello World'
+          }
+        })
+
+        await wrapper.find('i.ti.ti-x').trigger('click')
+
+        expect(wrapper.emitted('update:modelValue')).toBeUndefined()
+      })
+    })
+
     describe('When modelValue changes', () => {
       it('should emit update:modelValue when input value changes', async () => {
         wrapper = mount(VkInput, {

--- a/packages/valko-ui-components/src/__test__/Input.spec.ts
+++ b/packages/valko-ui-components/src/__test__/Input.spec.ts
@@ -508,6 +508,44 @@ describe('Input component', () => {
         expect(wrapper.emitted('update:modelValue')?.[0]).toEqual([5])
       })
     })
+
+    describe('When disableIconClickFocus prop changes', () => {
+      it('should not focus the input when left icon is clicked and disableIconClickFocus is true', async () => {
+        const wrapper = mount(VkInput, {
+          attachTo: document.body,
+          props: {
+            disableIconClickFocus: true
+          },
+          slots: {
+            'left-icon': '<i class="ti ti-home"></i>'
+          }
+        })
+
+        await wrapper.find('.vk-left-icon').trigger('click')
+
+        expect(wrapper.find('.vk-input__input').element).not.toBe(document.activeElement)
+
+        wrapper.unmount()
+      })
+
+      it('should focus the input when left icon is clicked and disableIconClickFocus is false', async () => {
+        const wrapper = mount(VkInput, {
+          attachTo: document.body,
+          props: {
+            disableIconClickFocus: false
+          },
+          slots: {
+            'left-icon': '<i class="ti ti-home"></i>'
+          }
+        })
+
+        await wrapper.find('.vk-left-icon').trigger('click')
+
+        expect(wrapper.find('.vk-input__input').element).toBe(document.activeElement)
+
+        wrapper.unmount()
+      })
+    })
   })
 
   describe('When extra functionality is added', () => {

--- a/packages/valko-ui-components/src/__test__/Select.spec.ts
+++ b/packages/valko-ui-components/src/__test__/Select.spec.ts
@@ -1,4 +1,4 @@
-import { nextTick } from 'vue'
+import { nextTick, h } from 'vue'
 import { VueWrapper, mount, DOMWrapper } from '@vue/test-utils'
 import VkSelect from '#valkoui/components/Select.vue'
 
@@ -9,7 +9,9 @@ describe('Select component', () => {
     { value: 3, label: 'Devon Webb' },
     { value: 4, label: 'Tom Cook' }
   ]
+
   let wrapper: VueWrapper
+
   describe('Props', () => {
     describe('With default props', () => {
       beforeEach(async () => {
@@ -914,6 +916,106 @@ describe('Select component', () => {
     })
   })
 
+  describe('Slots', () => {
+    it('should render left-icon slot content when provided', () => {
+      const wrapper = mount(VkSelect, {
+        props: { options },
+        slots: {
+          'left-icon': '<i class="test-left-icon"></i>'
+        }
+      })
+
+      expect(wrapper.find('i.test-left-icon').exists()).toBe(true)
+    })
+
+    it('should render right-icon slot content when provided', () => {
+      const wrapper = mount(VkSelect, {
+        props: { options },
+        slots: {
+          'right-icon': '<i class="test-right-icon"></i>'
+        }
+      })
+
+      expect(wrapper.find('i.test-right-icon').exists()).toBe(true)
+    })
+
+    it('should render default chevron-down icon when no suffix-icon slot is provided', () => {
+      const wrapper = mount(VkSelect, {
+        props: { options }
+      })
+
+      expect(wrapper.find('i.ti.ti-chevron-down').exists()).toBe(true)
+    })
+
+    it('should render custom suffix-icon slot content when provided', () => {
+      const wrapper = mount(VkSelect, {
+        props: { options },
+        slots: {
+          'suffix-icon': '<i class="test-suffix-icon"></i>'
+        }
+      })
+
+      expect(wrapper.find('i.test-suffix-icon').exists()).toBe(true)
+    })
+
+    it('should not render default chevron-down when custom suffix-icon is provided', () => {
+      const wrapper = mount(VkSelect, {
+        props: { options },
+        slots: {
+          'suffix-icon': '<i class="test-suffix-icon"></i>'
+        }
+      })
+
+      expect(wrapper.find('i.ti.ti-chevron-down').exists()).toBe(false)
+    })
+
+    it('should pass is-open as false to suffix-icon slot when dropdown is closed', () => {
+      const wrapper = mount(VkSelect, {
+        props: { options },
+        slots: {
+          'suffix-icon': (props: Record<string, unknown>) => h('span', {
+            class: 'custom-suffix', 'data-open': String(props.isOpen)
+          })
+        }
+      })
+
+      expect(wrapper.find('.custom-suffix').attributes('data-open')).toBe('false')
+    })
+
+    it('should pass is-open as true to suffix-icon slot when dropdown is open', async () => {
+      const wrapper = mount(VkSelect, {
+        props: { options },
+        slots: {
+          'suffix-icon': (props: Record<string, unknown>) => h('span', {
+            class: 'custom-suffix', 'data-open': String(props.isOpen)
+          })
+        }
+      })
+
+      await wrapper.find('.vk-input__input').trigger('focus')
+      await nextTick()
+
+      expect(wrapper.find('.custom-suffix').attributes('data-open')).toBe('true')
+    })
+
+    it('should pass toggle-dropdown function to suffix-icon slot', async () => {
+      const wrapper = mount(VkSelect, {
+        props: { options },
+        slots: {
+          'suffix-icon': (props: Record<string, unknown>) => h('button', {
+            class: 'custom-toggle',
+            onClick: () => (props.toggleDropdown as (open: boolean) => void)(true)
+          })
+        }
+      })
+
+      await wrapper.find('.custom-toggle').trigger('click')
+      await nextTick()
+
+      expect(wrapper.find('.vk-select__dropdown').exists()).toBe(true)
+    })
+  })
+
   describe('Emits', () => {
     it('should emit update event', async () => {
       const wrapper = mount(VkSelect, {
@@ -927,6 +1029,58 @@ describe('Select component', () => {
       wrapper.find('.vk-select__item:first-child').trigger('click')
 
       expect(wrapper.emitted()).toHaveProperty('update:modelValue')
+    })
+
+    it('should emit leftIconClick when left-icon slot content is clicked', async () => {
+      const wrapper = mount(VkSelect, {
+        props: { options },
+        slots: {
+          'left-icon': '<i class="test-left-icon"></i>'
+        }
+      })
+
+      await wrapper.find('i.test-left-icon').trigger('click')
+
+      expect(wrapper.emitted()).toHaveProperty('leftIconClick')
+    })
+
+    it('should emit rightIconClick when right-icon slot content is clicked', async () => {
+      const wrapper = mount(VkSelect, {
+        props: { options },
+        slots: {
+          'right-icon': '<i class="test-right-icon"></i>'
+        }
+      })
+
+      await wrapper.find('i.test-right-icon').trigger('click')
+
+      expect(wrapper.emitted()).toHaveProperty('rightIconClick')
+    })
+
+    it('should emit suffixIconClick when suffix-icon slot content is clicked', async () => {
+      const wrapper = mount(VkSelect, {
+        props: { options },
+        slots: {
+          'suffix-icon': '<i class="test-suffix-icon"></i>'
+        }
+      })
+
+      await wrapper.find('i.test-suffix-icon').trigger('click')
+
+      expect(wrapper.emitted()).toHaveProperty('suffixIconClick')
+    })
+
+    it('should not emit leftIconClick when component is disabled', async () => {
+      const wrapper = mount(VkSelect, {
+        props: { options, disabled: true },
+        slots: {
+          'left-icon': '<i class="test-left-icon"></i>'
+        }
+      })
+
+      await wrapper.find('i.test-left-icon').trigger('click')
+
+      expect(wrapper.emitted()).not.toHaveProperty('leftIconClick')
     })
   })
 })

--- a/packages/valko-ui-components/src/__test__/Select.spec.ts
+++ b/packages/valko-ui-components/src/__test__/Select.spec.ts
@@ -1,4 +1,4 @@
-import { nextTick, h } from 'vue'
+import { nextTick } from 'vue'
 import { VueWrapper, mount, DOMWrapper } from '@vue/test-utils'
 import VkSelect from '#valkoui/components/Select.vue'
 
@@ -927,93 +927,6 @@ describe('Select component', () => {
 
       expect(wrapper.find('i.test-left-icon').exists()).toBe(true)
     })
-
-    it('should render right-icon slot content when provided', () => {
-      const wrapper = mount(VkSelect, {
-        props: { options },
-        slots: {
-          'right-icon': '<i class="test-right-icon"></i>'
-        }
-      })
-
-      expect(wrapper.find('i.test-right-icon').exists()).toBe(true)
-    })
-
-    it('should render default chevron-down icon when no suffix-icon slot is provided', () => {
-      const wrapper = mount(VkSelect, {
-        props: { options }
-      })
-
-      expect(wrapper.find('i.ti.ti-chevron-down').exists()).toBe(true)
-    })
-
-    it('should render custom suffix-icon slot content when provided', () => {
-      const wrapper = mount(VkSelect, {
-        props: { options },
-        slots: {
-          'suffix-icon': '<i class="test-suffix-icon"></i>'
-        }
-      })
-
-      expect(wrapper.find('i.test-suffix-icon').exists()).toBe(true)
-    })
-
-    it('should not render default chevron-down when custom suffix-icon is provided', () => {
-      const wrapper = mount(VkSelect, {
-        props: { options },
-        slots: {
-          'suffix-icon': '<i class="test-suffix-icon"></i>'
-        }
-      })
-
-      expect(wrapper.find('i.ti.ti-chevron-down').exists()).toBe(false)
-    })
-
-    it('should pass is-open as false to suffix-icon slot when dropdown is closed', () => {
-      const wrapper = mount(VkSelect, {
-        props: { options },
-        slots: {
-          'suffix-icon': (props: Record<string, unknown>) => h('span', {
-            class: 'custom-suffix', 'data-open': String(props.isOpen)
-          })
-        }
-      })
-
-      expect(wrapper.find('.custom-suffix').attributes('data-open')).toBe('false')
-    })
-
-    it('should pass is-open as true to suffix-icon slot when dropdown is open', async () => {
-      const wrapper = mount(VkSelect, {
-        props: { options },
-        slots: {
-          'suffix-icon': (props: Record<string, unknown>) => h('span', {
-            class: 'custom-suffix', 'data-open': String(props.isOpen)
-          })
-        }
-      })
-
-      await wrapper.find('.vk-input__input').trigger('focus')
-      await nextTick()
-
-      expect(wrapper.find('.custom-suffix').attributes('data-open')).toBe('true')
-    })
-
-    it('should pass toggle-dropdown function to suffix-icon slot', async () => {
-      const wrapper = mount(VkSelect, {
-        props: { options },
-        slots: {
-          'suffix-icon': (props: Record<string, unknown>) => h('button', {
-            class: 'custom-toggle',
-            onClick: () => (props.toggleDropdown as (open: boolean) => void)(true)
-          })
-        }
-      })
-
-      await wrapper.find('.custom-toggle').trigger('click')
-      await nextTick()
-
-      expect(wrapper.find('.vk-select__dropdown').exists()).toBe(true)
-    })
   })
 
   describe('Emits', () => {
@@ -1042,32 +955,6 @@ describe('Select component', () => {
       await wrapper.find('i.test-left-icon').trigger('click')
 
       expect(wrapper.emitted()).toHaveProperty('leftIconClick')
-    })
-
-    it('should emit rightIconClick when right-icon slot content is clicked', async () => {
-      const wrapper = mount(VkSelect, {
-        props: { options },
-        slots: {
-          'right-icon': '<i class="test-right-icon"></i>'
-        }
-      })
-
-      await wrapper.find('i.test-right-icon').trigger('click')
-
-      expect(wrapper.emitted()).toHaveProperty('rightIconClick')
-    })
-
-    it('should emit suffixIconClick when suffix-icon slot content is clicked', async () => {
-      const wrapper = mount(VkSelect, {
-        props: { options },
-        slots: {
-          'suffix-icon': '<i class="test-suffix-icon"></i>'
-        }
-      })
-
-      await wrapper.find('i.test-suffix-icon').trigger('click')
-
-      expect(wrapper.emitted()).toHaveProperty('suffixIconClick')
     })
 
     it('should not emit leftIconClick when component is disabled', async () => {

--- a/packages/valko-ui-components/src/__test__/Select.spec.ts
+++ b/packages/valko-ui-components/src/__test__/Select.spec.ts
@@ -300,6 +300,44 @@ describe('Select component', () => {
         expect(wrapper.find('.vk-input__helper').text()).toContain('Hello World')
       })
     })
+
+    describe('When disableIconClickFocus prop changes', () => {
+      it('should not focus the input when left icon is clicked and disableIconClickFocus is true', async () => {
+        const wrapper = mount(VkSelect, {
+          attachTo: document.body,
+          props: {
+            disableIconClickFocus: true
+          },
+          slots: {
+            'left-icon': '<i class="ti ti-home"></i>'
+          }
+        })
+
+        await wrapper.find('.vk-left-icon').trigger('click')
+
+        expect(wrapper.find('.vk-input__input').element).not.toBe(document.activeElement)
+
+        wrapper.unmount()
+      })
+
+      it('should focus the input when left icon is clicked and disableIconClickFocus is false', async () => {
+        const wrapper = mount(VkSelect, {
+          attachTo: document.body,
+          props: {
+            disableIconClickFocus: false
+          },
+          slots: {
+            'left-icon': '<i class="ti ti-home"></i>'
+          }
+        })
+
+        await wrapper.find('.vk-left-icon').trigger('click')
+
+        expect(wrapper.find('.vk-input__input').element).toBe(document.activeElement)
+
+        wrapper.unmount()
+      })
+    })
   })
 
   describe('Methods', () => {

--- a/packages/valko-ui-components/src/components/Input.vue
+++ b/packages/valko-ui-components/src/components/Input.vue
@@ -17,7 +17,8 @@ const props = withDefaults(defineProps<InputProps>(), {
   clearable: false,
   step: 1,
   min: -Infinity,
-  max: Infinity
+  max: Infinity,
+  iconClickFocus: true
 })
 
 const emit = defineEmits(['update:modelValue', 'focus', 'clear', 'blur', 'leftIconClick', 'rightIconClick'])
@@ -59,10 +60,10 @@ const clearInput = () => {
 }
 
 const handleIconClick = (icon: 'left' | 'right') => {
-  if (!props.disabled && !props.readonly) {
-    emit(`${icon}IconClick`)
-    inputRef.value?.focus()
-  }
+  if (props.disabled) return
+
+  emit(`${icon}IconClick`)
+  if (props.iconClickFocus) inputRef.value?.focus()
 }
 
 const changeNumericValue = (action: 'increment' | 'decrement') => {
@@ -170,7 +171,7 @@ watch(() => props.modelValue, (newValue) => {
         @touchend="clearInput"
       />
       <span
-        v-if="$slots['left-icon']"
+        v-if="$slots['left-icon'] && $slots['left-icon']().length"
         :class="[s.icons({ class: styleSlots?.icons }), s.leftIcon({ class: styleSlots?.leftIcon })]"
         @click="handleIconClick('left')"
         @touchend="handleIconClick('left')"
@@ -178,7 +179,7 @@ watch(() => props.modelValue, (newValue) => {
         <slot name="left-icon" />
       </span>
       <span
-        v-if="$slots['right-icon']"
+        v-if="$slots['right-icon'] && $slots['right-icon']().length"
         :data-chevron-icons="type === 'number'"
         :class="[s.icons({ class: styleSlots?.icons }), s.rightIcon({ class: styleSlots?.rightIcon })]"
         @click="handleIconClick('right')"

--- a/packages/valko-ui-components/src/components/Input.vue
+++ b/packages/valko-ui-components/src/components/Input.vue
@@ -15,6 +15,7 @@ const props = withDefaults(defineProps<InputProps>(), {
   cursor: 'text',
   modelValue: '',
   clearable: false,
+  forceClearable: false,
   step: 1,
   min: -Infinity,
   max: Infinity,
@@ -54,7 +55,7 @@ const onBlur = (event: Event) => {
 }
 
 const clearInput = () => {
-  if (props.disabled) return
+  if (props.disabled || (props.readonly && !props.forceClearable)) return
   inputValue.value = ''
   emit('update:modelValue', '')
   emit('clear')

--- a/packages/valko-ui-components/src/components/Input.vue
+++ b/packages/valko-ui-components/src/components/Input.vue
@@ -101,14 +101,14 @@ const describedBy = computed(() => {
   return ids.length > 0 ? ids.join(' ') : undefined
 })
 
-const rightIconCount = computed(() => {
+const rightIconCount = () => {
   let count = 0
   if (props.clearable) count++
   if (slots['right-icon']) count++
   if (slots['suffix-icon']) count++
   if (props.type === 'number') count++
   return count
-})
+}
 
 watch(() => props.modelValue, (newValue) => {
   inputValue.value = newValue
@@ -122,7 +122,7 @@ watch(() => props.modelValue, (newValue) => {
       <input
         ref="inputRef"
         :data-left-icon="!!$slots['left-icon']"
-        :data-right-icon-count="rightIconCount"
+        :data-right-icon-count="rightIconCount()"
         :class="s.input({ class: styleSlots?.input })"
         :readonly="readonly"
         :disabled="disabled"
@@ -158,7 +158,7 @@ watch(() => props.modelValue, (newValue) => {
         <slot name="left-icon" />
       </span>
       <div
-        v-if="rightIconCount > 0"
+        v-if="rightIconCount() > 0"
         :class="s.rightIconsContainer({ class: styleSlots?.rightIconsContainer })"
       >
         <vk-icon

--- a/packages/valko-ui-components/src/components/Input.vue
+++ b/packages/valko-ui-components/src/components/Input.vue
@@ -54,6 +54,7 @@ const onBlur = (event: Event) => {
 }
 
 const clearInput = () => {
+  if (props.disabled) return
   inputValue.value = ''
   emit('update:modelValue', '')
   emit('clear')

--- a/packages/valko-ui-components/src/components/Input.vue
+++ b/packages/valko-ui-components/src/components/Input.vue
@@ -170,7 +170,7 @@ watch(() => props.modelValue, (newValue) => {
         />
         <span
           v-if="$slots['right-icon']"
-          :class="s.icons({ class: styleSlots?.icons })"
+          :class="[s.icons({ class: styleSlots?.icons }), s.rightIcon({ class: styleSlots?.rightIcon })]"
           @click="handleIconClick('right')"
           @touchend="handleIconClick('right')"
         >
@@ -178,7 +178,7 @@ watch(() => props.modelValue, (newValue) => {
         </span>
         <span
           v-if="$slots['suffix-icon']"
-          :class="s.icons({ class: styleSlots?.icons })"
+          :class="[s.icons({ class: styleSlots?.icons }), s.suffixIcon({ class: styleSlots?.suffixIcon })]"
           @click="handleIconClick('suffix')"
           @touchend="handleIconClick('suffix')"
         >

--- a/packages/valko-ui-components/src/components/Input.vue
+++ b/packages/valko-ui-components/src/components/Input.vue
@@ -171,7 +171,7 @@ watch(() => props.modelValue, (newValue) => {
         @touchend="clearInput"
       />
       <span
-        v-if="$slots['left-icon'] && $slots['left-icon']().length"
+        v-if="$slots['left-icon']"
         :class="[s.icons({ class: styleSlots?.icons }), s.leftIcon({ class: styleSlots?.leftIcon })]"
         @click="handleIconClick('left')"
         @touchend="handleIconClick('left')"
@@ -179,7 +179,7 @@ watch(() => props.modelValue, (newValue) => {
         <slot name="left-icon" />
       </span>
       <span
-        v-if="$slots['right-icon'] && $slots['right-icon']().length"
+        v-if="$slots['right-icon']"
         :data-chevron-icons="type === 'number'"
         :class="[s.icons({ class: styleSlots?.icons }), s.rightIcon({ class: styleSlots?.rightIcon })]"
         @click="handleIconClick('right')"

--- a/packages/valko-ui-components/src/components/Input.vue
+++ b/packages/valko-ui-components/src/components/Input.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { useId, ref, watch, computed } from 'vue'
+import { useId, useSlots, ref, watch, computed } from 'vue'
 import type { InputProps } from '#valkoui/types/Input'
 import styles from '#valkoui/styles/Input.styles.ts'
 import VkIcon from './Icon.vue'
@@ -18,13 +18,14 @@ const props = withDefaults(defineProps<InputProps>(), {
   step: 1,
   min: -Infinity,
   max: Infinity,
-  iconClickFocus: true
+  disableIconClickFocus: false
 })
 
-const emit = defineEmits(['update:modelValue', 'focus', 'clear', 'blur', 'leftIconClick', 'rightIconClick'])
+const emit = defineEmits(['update:modelValue', 'focus', 'clear', 'blur', 'leftIconClick', 'rightIconClick', 'suffixIconClick'])
 
 const s = computed(() => styles(props))
 
+const slots = useSlots()
 const inputId = useId()
 const helpertextId = useId()
 const isFilled = ref(false)
@@ -59,11 +60,11 @@ const clearInput = () => {
   isFilled.value = false
 }
 
-const handleIconClick = (icon: 'left' | 'right') => {
+const handleIconClick = (icon: 'left' | 'right' | 'suffix') => {
   if (props.disabled) return
 
   emit(`${icon}IconClick`)
-  if (props.iconClickFocus) inputRef.value?.focus()
+  if (!props.disableIconClickFocus) inputRef.value?.focus()
 }
 
 const changeNumericValue = (action: 'increment' | 'decrement') => {
@@ -100,6 +101,15 @@ const describedBy = computed(() => {
   return ids.length > 0 ? ids.join(' ') : undefined
 })
 
+const rightIconCount = computed(() => {
+  let count = 0
+  if (props.clearable) count++
+  if (slots['right-icon']) count++
+  if (slots['suffix-icon']) count++
+  if (props.type === 'number') count++
+  return count
+})
+
 watch(() => props.modelValue, (newValue) => {
   inputValue.value = newValue
   isFilled.value = newValue !== null && newValue !== undefined && newValue !== ''
@@ -112,8 +122,7 @@ watch(() => props.modelValue, (newValue) => {
       <input
         ref="inputRef"
         :data-left-icon="!!$slots['left-icon']"
-        :data-right-icon="!!$slots['right-icon']"
-        :data-clear-icon="clearable"
+        :data-right-icon-count="rightIconCount"
         :class="s.input({ class: styleSlots?.input })"
         :readonly="readonly"
         :disabled="disabled"
@@ -141,36 +150,6 @@ watch(() => props.modelValue, (newValue) => {
         {{ label }}
       </label>
       <span
-        v-if="type === 'number'"
-        :class="s.numberArrows({ class: styleSlots?.numberArrows })"
-      >
-        <vk-icon
-          name="chevron-up"
-          :class="s.chevrons({ class: styleSlots?.chevrons })"
-          @mousedown="handleNumericArrowHold('increment')"
-          @mouseup="handleNumericArrowRelease"
-          @mouseleave="handleNumericArrowRelease"
-          @touchstart="handleNumericArrowHold('increment')"
-        />
-        <vk-icon
-          name="chevron-down"
-          :class="s.chevrons({ class: styleSlots?.chevrons })"
-          @mousedown="handleNumericArrowHold('decrement')"
-          @mouseup="handleNumericArrowRelease"
-          @mouseleave="handleNumericArrowRelease"
-          @touchstart="handleNumericArrowHold('decrement')"
-        />
-      </span>
-      <vk-icon
-        v-if="clearable && !!inputValue"
-        name="x"
-        :data-right-icon="!!$slots['right-icon']"
-        :data-chevron-icons="type === 'number'"
-        :class="s.clearIcon({ class: styleSlots?.clearIcon })"
-        @click="clearInput"
-        @touchend="clearInput"
-      />
-      <span
         v-if="$slots['left-icon']"
         :class="[s.icons({ class: styleSlots?.icons }), s.leftIcon({ class: styleSlots?.leftIcon })]"
         @click="handleIconClick('left')"
@@ -178,15 +157,55 @@ watch(() => props.modelValue, (newValue) => {
       >
         <slot name="left-icon" />
       </span>
-      <span
-        v-if="$slots['right-icon']"
-        :data-chevron-icons="type === 'number'"
-        :class="[s.icons({ class: styleSlots?.icons }), s.rightIcon({ class: styleSlots?.rightIcon })]"
-        @click="handleIconClick('right')"
-        @touchend="handleIconClick('right')"
+      <div
+        v-if="rightIconCount > 0"
+        :class="s.rightIconsContainer({ class: styleSlots?.rightIconsContainer })"
       >
-        <slot name="right-icon" />
-      </span>
+        <vk-icon
+          v-if="clearable && !!inputValue"
+          name="x"
+          :class="s.clearIcon({ class: styleSlots?.clearIcon })"
+          @click="clearInput"
+          @touchend="clearInput"
+        />
+        <span
+          v-if="$slots['right-icon']"
+          :class="s.icons({ class: styleSlots?.icons })"
+          @click="handleIconClick('right')"
+          @touchend="handleIconClick('right')"
+        >
+          <slot name="right-icon" />
+        </span>
+        <span
+          v-if="$slots['suffix-icon']"
+          :class="s.icons({ class: styleSlots?.icons })"
+          @click="handleIconClick('suffix')"
+          @touchend="handleIconClick('suffix')"
+        >
+          <slot name="suffix-icon" />
+        </span>
+        <span
+          v-if="type === 'number'"
+          :class="s.numberArrows({ class: styleSlots?.numberArrows })"
+        >
+          <vk-icon
+            name="chevron-up"
+            :class="s.chevrons({ class: styleSlots?.chevrons })"
+            @mousedown="handleNumericArrowHold('increment')"
+            @mouseup="handleNumericArrowRelease"
+            @mouseleave="handleNumericArrowRelease"
+            @touchstart="handleNumericArrowHold('increment')"
+          />
+          <vk-icon
+            name="chevron-down"
+            :class="s.chevrons({ class: styleSlots?.chevrons })"
+            @mousedown="handleNumericArrowHold('decrement')"
+            @mouseup="handleNumericArrowRelease"
+            @mouseleave="handleNumericArrowRelease"
+            @touchstart="handleNumericArrowHold('decrement')"
+          />
+        </span>
+      </div>
     </div>
     <span
       v-if="helpertext"

--- a/packages/valko-ui-components/src/components/Input.vue
+++ b/packages/valko-ui-components/src/components/Input.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { useId, useSlots, ref, watch, computed } from 'vue'
+import { useId, ref, watch, computed } from 'vue'
 import type { InputProps } from '#valkoui/types/Input'
 import styles from '#valkoui/styles/Input.styles.ts'
 import VkIcon from './Icon.vue'
@@ -15,18 +15,15 @@ const props = withDefaults(defineProps<InputProps>(), {
   cursor: 'text',
   modelValue: '',
   clearable: false,
-  forceClearable: false,
   step: 1,
   min: -Infinity,
-  max: Infinity,
-  disableIconClickFocus: false
+  max: Infinity
 })
 
-const emit = defineEmits(['update:modelValue', 'focus', 'clear', 'blur', 'leftIconClick', 'rightIconClick', 'suffixIconClick'])
+const emit = defineEmits(['update:modelValue', 'focus', 'clear', 'blur', 'leftIconClick', 'rightIconClick'])
 
 const s = computed(() => styles(props))
 
-const slots = useSlots()
 const inputId = useId()
 const helpertextId = useId()
 const isFilled = ref(false)
@@ -55,18 +52,17 @@ const onBlur = (event: Event) => {
 }
 
 const clearInput = () => {
-  if (props.disabled || (props.readonly && !props.forceClearable)) return
   inputValue.value = ''
   emit('update:modelValue', '')
   emit('clear')
   isFilled.value = false
 }
 
-const handleIconClick = (icon: 'left' | 'right' | 'suffix') => {
-  if (props.disabled) return
-
-  emit(`${icon}IconClick`)
-  if (!props.disableIconClickFocus) inputRef.value?.focus()
+const handleIconClick = (icon: 'left' | 'right') => {
+  if (!props.disabled && !props.readonly) {
+    emit(`${icon}IconClick`)
+    inputRef.value?.focus()
+  }
 }
 
 const changeNumericValue = (action: 'increment' | 'decrement') => {
@@ -103,15 +99,6 @@ const describedBy = computed(() => {
   return ids.length > 0 ? ids.join(' ') : undefined
 })
 
-const rightIconCount = () => {
-  let count = 0
-  if (props.clearable) count++
-  if (slots['right-icon']) count++
-  if (slots['suffix-icon']) count++
-  if (props.type === 'number') count++
-  return count
-}
-
 watch(() => props.modelValue, (newValue) => {
   inputValue.value = newValue
   isFilled.value = newValue !== null && newValue !== undefined && newValue !== ''
@@ -124,7 +111,8 @@ watch(() => props.modelValue, (newValue) => {
       <input
         ref="inputRef"
         :data-left-icon="!!$slots['left-icon']"
-        :data-right-icon-count="rightIconCount()"
+        :data-right-icon="!!$slots['right-icon']"
+        :data-clear-icon="clearable"
         :class="s.input({ class: styleSlots?.input })"
         :readonly="readonly"
         :disabled="disabled"
@@ -152,6 +140,36 @@ watch(() => props.modelValue, (newValue) => {
         {{ label }}
       </label>
       <span
+        v-if="type === 'number'"
+        :class="s.numberArrows({ class: styleSlots?.numberArrows })"
+      >
+        <vk-icon
+          name="chevron-up"
+          :class="s.chevrons({ class: styleSlots?.chevrons })"
+          @mousedown="handleNumericArrowHold('increment')"
+          @mouseup="handleNumericArrowRelease"
+          @mouseleave="handleNumericArrowRelease"
+          @touchstart="handleNumericArrowHold('increment')"
+        />
+        <vk-icon
+          name="chevron-down"
+          :class="s.chevrons({ class: styleSlots?.chevrons })"
+          @mousedown="handleNumericArrowHold('decrement')"
+          @mouseup="handleNumericArrowRelease"
+          @mouseleave="handleNumericArrowRelease"
+          @touchstart="handleNumericArrowHold('decrement')"
+        />
+      </span>
+      <vk-icon
+        v-if="clearable && !!inputValue"
+        name="x"
+        :data-right-icon="!!$slots['right-icon']"
+        :data-chevron-icons="type === 'number'"
+        :class="s.clearIcon({ class: styleSlots?.clearIcon })"
+        @click="clearInput"
+        @touchend="clearInput"
+      />
+      <span
         v-if="$slots['left-icon']"
         :class="[s.icons({ class: styleSlots?.icons }), s.leftIcon({ class: styleSlots?.leftIcon })]"
         @click="handleIconClick('left')"
@@ -159,55 +177,15 @@ watch(() => props.modelValue, (newValue) => {
       >
         <slot name="left-icon" />
       </span>
-      <div
-        v-if="rightIconCount() > 0"
-        :class="s.rightIconsContainer({ class: styleSlots?.rightIconsContainer })"
+      <span
+        v-if="$slots['right-icon']"
+        :data-chevron-icons="type === 'number'"
+        :class="[s.icons({ class: styleSlots?.icons }), s.rightIcon({ class: styleSlots?.rightIcon })]"
+        @click="handleIconClick('right')"
+        @touchend="handleIconClick('right')"
       >
-        <vk-icon
-          v-if="clearable && !!inputValue"
-          name="x"
-          :class="s.clearIcon({ class: styleSlots?.clearIcon })"
-          @click="clearInput"
-          @touchend="clearInput"
-        />
-        <span
-          v-if="$slots['right-icon']"
-          :class="[s.icons({ class: styleSlots?.icons }), s.rightIcon({ class: styleSlots?.rightIcon })]"
-          @click="handleIconClick('right')"
-          @touchend="handleIconClick('right')"
-        >
-          <slot name="right-icon" />
-        </span>
-        <span
-          v-if="$slots['suffix-icon']"
-          :class="[s.icons({ class: styleSlots?.icons }), s.suffixIcon({ class: styleSlots?.suffixIcon })]"
-          @click="handleIconClick('suffix')"
-          @touchend="handleIconClick('suffix')"
-        >
-          <slot name="suffix-icon" />
-        </span>
-        <span
-          v-if="type === 'number'"
-          :class="s.numberArrows({ class: styleSlots?.numberArrows })"
-        >
-          <vk-icon
-            name="chevron-up"
-            :class="s.chevrons({ class: styleSlots?.chevrons })"
-            @mousedown="handleNumericArrowHold('increment')"
-            @mouseup="handleNumericArrowRelease"
-            @mouseleave="handleNumericArrowRelease"
-            @touchstart="handleNumericArrowHold('increment')"
-          />
-          <vk-icon
-            name="chevron-down"
-            :class="s.chevrons({ class: styleSlots?.chevrons })"
-            @mousedown="handleNumericArrowHold('decrement')"
-            @mouseup="handleNumericArrowRelease"
-            @mouseleave="handleNumericArrowRelease"
-            @touchstart="handleNumericArrowHold('decrement')"
-          />
-        </span>
-      </div>
+        <slot name="right-icon" />
+      </span>
     </div>
     <span
       v-if="helpertext"

--- a/packages/valko-ui-components/src/components/Input.vue
+++ b/packages/valko-ui-components/src/components/Input.vue
@@ -52,6 +52,7 @@ const onBlur = (event: Event) => {
 }
 
 const clearInput = () => {
+  if (props.disabled || (props.readonly && !props.forceClearable)) return
   inputValue.value = ''
   emit('update:modelValue', '')
   emit('clear')
@@ -59,7 +60,7 @@ const clearInput = () => {
 }
 
 const handleIconClick = (icon: 'left' | 'right') => {
-  if (!props.disabled && !props.readonly) {
+  if (!props.disabled) {
     emit(`${icon}IconClick`)
     inputRef.value?.focus()
   }

--- a/packages/valko-ui-components/src/components/Input.vue
+++ b/packages/valko-ui-components/src/components/Input.vue
@@ -60,10 +60,11 @@ const clearInput = () => {
 }
 
 const handleIconClick = (icon: 'left' | 'right') => {
-  if (!props.disabled) {
-    emit(`${icon}IconClick`)
-    inputRef.value?.focus()
-  }
+  if (props.disabled) return
+
+  emit(`${icon}IconClick`)
+
+  if (!props.disableIconClickFocus) inputRef.value?.focus()
 }
 
 const changeNumericValue = (action: 'increment' | 'decrement') => {

--- a/packages/valko-ui-components/src/components/Select.vue
+++ b/packages/valko-ui-components/src/components/Select.vue
@@ -201,7 +201,7 @@ onUnmounted(() => {
               name="chevron-down"
               :data-open="isOpen"
               :class="s.suffixIcon({ class: styleSlots?.suffixIcon })"
-              @click.stop="toggleDropdown(!isOpen)"
+              @click="toggleDropdown(!isOpen)"
             />
           </slot>
         </template>

--- a/packages/valko-ui-components/src/components/Select.vue
+++ b/packages/valko-ui-components/src/components/Select.vue
@@ -19,7 +19,7 @@ const props = withDefaults(defineProps<SelectProps>(), {
   readonly: false
 })
 
-const emit = defineEmits(['update:modelValue'])
+const emit = defineEmits(['update:modelValue', 'leftIconClick'])
 
 const s = computed(() => styles(props))
 
@@ -171,6 +171,7 @@ onUnmounted(() => {
         @clear="clearSelection"
         @keydown="handleKeyDown"
         @keydown.escape="toggleDropdown(false)"
+        @left-icon-click="emit('leftIconClick', $event)"
       >
         <template
           #left-icon

--- a/packages/valko-ui-components/src/components/Select.vue
+++ b/packages/valko-ui-components/src/components/Select.vue
@@ -20,7 +20,7 @@ const props = withDefaults(defineProps<SelectProps>(), {
   disableIconClickFocus: true
 })
 
-const emit = defineEmits(['update:modelValue', 'leftIconClick', 'rightIconClick'])
+const emit = defineEmits(['update:modelValue', 'leftIconClick', 'rightIconClick', 'suffixIconClick'])
 
 const s = computed(() => styles(props))
 
@@ -174,6 +174,7 @@ onUnmounted(() => {
         @keydown="handleKeyDown"
         @keydown.escape="toggleDropdown(false)"
         @left-icon-click="emit('leftIconClick')"
+        @suffix-icon-click="emit('suffixIconClick')"
         @right-icon-click="emit('rightIconClick')"
       >
         <template

--- a/packages/valko-ui-components/src/components/Select.vue
+++ b/packages/valko-ui-components/src/components/Select.vue
@@ -172,6 +172,12 @@ onUnmounted(() => {
         @keydown="handleKeyDown"
         @keydown.escape="toggleDropdown(false)"
       >
+        <template
+          #left-icon
+          v-if="$slots['left-icon']"
+        >
+          <slot name="left-icon" />
+        </template>
         <template #right-icon>
           <vk-icon
             name="chevron-down"

--- a/packages/valko-ui-components/src/components/Select.vue
+++ b/packages/valko-ui-components/src/components/Select.vue
@@ -16,8 +16,7 @@ const props = withDefaults(defineProps<SelectProps>(), {
   clearable: false,
   multiple: false,
   disabled: false,
-  readonly: false,
-  disableIconClickFocus: true
+  readonly: false
 })
 
 const emit = defineEmits(['update:modelValue', 'leftIconClick', 'rightIconClick', 'suffixIconClick'])
@@ -152,6 +151,7 @@ onUnmounted(() => {
     <div :class="s.field({ class: styleSlots?.field })">
       <vk-input
         readonly
+        disable-icon-click-focus
         :helpertext="helpertext"
         :label="label"
         :disabled="disabled"
@@ -161,13 +161,13 @@ onUnmounted(() => {
         :shape="shape"
         :model-value="showValue"
         :clearable="clearable"
+        :force-clearable="clearable"
         cursor="pointer"
         :aria-label="ariaLabel"
         :aria-labelledby="ariaLabelledBy"
         :aria-describedby="ariaDescribedBy"
         :aria-invalid="ariaInvalid"
         :aria-required="ariaRequired"
-        :disable-icon-click-focus="disableIconClickFocus"
         @focus="toggleDropdown(true)"
         @blur="toggleDropdown(false)"
         @clear="clearSelection"

--- a/packages/valko-ui-components/src/components/Select.vue
+++ b/packages/valko-ui-components/src/components/Select.vue
@@ -19,7 +19,7 @@ const props = withDefaults(defineProps<SelectProps>(), {
   readonly: false
 })
 
-const emit = defineEmits(['update:modelValue'])
+const emit = defineEmits(['update:modelValue', 'leftIconClick', 'rightIconClick'])
 
 const s = computed(() => styles(props))
 
@@ -160,6 +160,7 @@ onUnmounted(() => {
         :shape="shape"
         :model-value="showValue"
         :clearable="clearable"
+        :icon-click-focus="false"
         cursor="pointer"
         :aria-label="ariaLabel"
         :aria-labelledby="ariaLabelledBy"
@@ -171,16 +172,24 @@ onUnmounted(() => {
         @clear="clearSelection"
         @keydown="handleKeyDown"
         @keydown.escape="toggleDropdown(false)"
+        @left-icon-click="emit('leftIconClick')"
+        @right-icon-click="emit('rightIconClick')"
       >
-        <template #right-icon>
-          <vk-icon
-            name="chevron-down"
-            :data-open="isOpen"
-            :class="s.icon({ class: styleSlots?.icon })"
-            @click.stop="toggleDropdown(!isOpen)"
-          />
+        <template
+          v-for="(_, slotName) in $slots"
+          #[slotName]
+        >
+          <slot :name="slotName" />
         </template>
       </vk-input>
+
+      <vk-icon
+        name="chevron-down"
+        :data-open="isOpen"
+        :class="s.chevronIcon({ class: styleSlots?.chevronIcon })"
+        @click.stop="toggleDropdown(!isOpen)"
+      />
+
       <transition
         enter-active-class="transition-all duration-200 ease-out origin-top"
         enter-from-class="opacity-50 scale-y-90"

--- a/packages/valko-ui-components/src/components/Select.vue
+++ b/packages/valko-ui-components/src/components/Select.vue
@@ -161,6 +161,7 @@ onUnmounted(() => {
         :model-value="showValue"
         :clearable="clearable"
         cursor="pointer"
+        :disable-icon-click-focus="disableIconClickFocus"
         :aria-label="ariaLabel"
         :aria-labelledby="ariaLabelledBy"
         :aria-describedby="ariaDescribedBy"

--- a/packages/valko-ui-components/src/components/Select.vue
+++ b/packages/valko-ui-components/src/components/Select.vue
@@ -186,6 +186,7 @@ onUnmounted(() => {
       <vk-icon
         name="chevron-down"
         :data-open="isOpen"
+        :data-helpertext="!!helpertext"
         :class="s.chevronIcon({ class: styleSlots?.chevronIcon })"
         @click.stop="toggleDropdown(!isOpen)"
       />

--- a/packages/valko-ui-components/src/components/Select.vue
+++ b/packages/valko-ui-components/src/components/Select.vue
@@ -16,7 +16,8 @@ const props = withDefaults(defineProps<SelectProps>(), {
   clearable: false,
   multiple: false,
   disabled: false,
-  readonly: false
+  readonly: false,
+  disableIconClickFocus: true
 })
 
 const emit = defineEmits(['update:modelValue', 'leftIconClick', 'rightIconClick'])
@@ -160,13 +161,13 @@ onUnmounted(() => {
         :shape="shape"
         :model-value="showValue"
         :clearable="clearable"
-        :icon-click-focus="false"
         cursor="pointer"
         :aria-label="ariaLabel"
         :aria-labelledby="ariaLabelledBy"
         :aria-describedby="ariaDescribedBy"
         :aria-invalid="ariaInvalid"
         :aria-required="ariaRequired"
+        :disable-icon-click-focus="disableIconClickFocus"
         @focus="toggleDropdown(true)"
         @blur="toggleDropdown(false)"
         @clear="clearSelection"
@@ -176,20 +177,34 @@ onUnmounted(() => {
         @right-icon-click="emit('rightIconClick')"
       >
         <template
-          v-for="(_, slotName) in $slots"
-          #[slotName]
+          v-if="$slots['left-icon']"
+          #left-icon
         >
-          <slot :name="slotName" />
+          <slot name="left-icon" />
+        </template>
+
+        <template
+          v-if="$slots['right-icon']"
+          #right-icon
+        >
+          <slot name="right-icon" />
+        </template>
+
+        <template #suffix-icon>
+          <slot
+            name="suffix-icon"
+            :toggle-dropdown="toggleDropdown"
+            :is-open="isOpen"
+          >
+            <vk-icon
+              name="chevron-down"
+              :data-open="isOpen"
+              :class="s.suffixIcon({ class: styleSlots?.suffixIcon })"
+              @click.stop="toggleDropdown(!isOpen)"
+            />
+          </slot>
         </template>
       </vk-input>
-
-      <vk-icon
-        name="chevron-down"
-        :data-open="isOpen"
-        :data-helpertext="!!helpertext"
-        :class="s.chevronIcon({ class: styleSlots?.chevronIcon })"
-        @click.stop="toggleDropdown(!isOpen)"
-      />
 
       <transition
         enter-active-class="transition-all duration-200 ease-out origin-top"

--- a/packages/valko-ui-components/src/components/Select.vue
+++ b/packages/valko-ui-components/src/components/Select.vue
@@ -19,7 +19,7 @@ const props = withDefaults(defineProps<SelectProps>(), {
   readonly: false
 })
 
-const emit = defineEmits(['update:modelValue', 'leftIconClick', 'rightIconClick', 'suffixIconClick'])
+const emit = defineEmits(['update:modelValue'])
 
 const s = computed(() => styles(props))
 
@@ -151,7 +151,6 @@ onUnmounted(() => {
     <div :class="s.field({ class: styleSlots?.field })">
       <vk-input
         readonly
-        disable-icon-click-focus
         :helpertext="helpertext"
         :label="label"
         :disabled="disabled"
@@ -161,7 +160,6 @@ onUnmounted(() => {
         :shape="shape"
         :model-value="showValue"
         :clearable="clearable"
-        :force-clearable="clearable"
         cursor="pointer"
         :aria-label="ariaLabel"
         :aria-labelledby="ariaLabelledBy"
@@ -173,40 +171,16 @@ onUnmounted(() => {
         @clear="clearSelection"
         @keydown="handleKeyDown"
         @keydown.escape="toggleDropdown(false)"
-        @left-icon-click="emit('leftIconClick')"
-        @suffix-icon-click="emit('suffixIconClick')"
-        @right-icon-click="emit('rightIconClick')"
       >
-        <template
-          v-if="$slots['left-icon']"
-          #left-icon
-        >
-          <slot name="left-icon" />
-        </template>
-
-        <template
-          v-if="$slots['right-icon']"
-          #right-icon
-        >
-          <slot name="right-icon" />
-        </template>
-
-        <template #suffix-icon>
-          <slot
-            name="suffix-icon"
-            :toggle-dropdown="toggleDropdown"
-            :is-open="isOpen"
-          >
-            <vk-icon
-              name="chevron-down"
-              :data-open="isOpen"
-              :class="s.suffixIcon({ class: styleSlots?.suffixIcon })"
-              @click="toggleDropdown(!isOpen)"
-            />
-          </slot>
+        <template #right-icon>
+          <vk-icon
+            name="chevron-down"
+            :data-open="isOpen"
+            :class="s.icon({ class: styleSlots?.icon })"
+            @click.stop="toggleDropdown(!isOpen)"
+          />
         </template>
       </vk-input>
-
       <transition
         enter-active-class="transition-all duration-200 ease-out origin-top"
         enter-from-class="opacity-50 scale-y-90"

--- a/packages/valko-ui-components/src/styles/Input.styles.ts
+++ b/packages/valko-ui-components/src/styles/Input.styles.ts
@@ -62,29 +62,26 @@ const input = tv({
       'vk-input__icons',
       'cursor-pointer',
       'text-on-surface-variant',
-      'transition-all'
-    ],
-    rightIconsContainer: [
-      'vk-input__right-icons',
       'absolute',
-      'right-3',
+      'transition-all',
       'top-1/2',
-      '-translate-y-1/2',
-      'flex',
-      'items-center'
+      '-translate-y-1/2'
     ],
-    rightIcon: [],
+    rightIcon: [
+      'right-3'
+    ],
     leftIcon: [
-      'absolute',
-      'top-1/2',
-      '-translate-y-1/2',
       'left-3'
     ],
     clearIcon: [
       'vk-input__clear-icon',
       'text-on-surface-variant',
       'cursor-pointer',
-      'transition-all'
+      'absolute',
+      'transition-all',
+      'top-1/2',
+      '-translate-y-1/2',
+      'right-3'
     ],
     numberArrows: [
       'vk-input__number-arrows',
@@ -92,10 +89,13 @@ const input = tv({
       'flex',
       'flex-col',
       'gap-1',
+      'absolute',
+      'right-3',
+      'top-1/2',
+      '-translate-y-1/2',
       'cursor-pointer'
     ],
-    chevrons: [],
-    suffixIcon: []
+    chevrons: []
   },
   variants: {
     variant: {
@@ -301,10 +301,9 @@ const input = tv({
           'pt-2',
           'text-xs',
           'data-[left-icon=true]:pl-11',
-          'data-[right-icon-count="1"]:pr-11',
-          'data-[right-icon-count="2"]:pr-17',
-          'data-[right-icon-count="3"]:pr-23',
-          'data-[right-icon-count="4"]:pr-29'
+          'data-[right-icon=true]:data-[clear-icon=false]:pr-11',
+          'data-[right-icon=true]:data-[clear-icon=true]:pr-17',
+          'data-[clear-icon=true]:data-[right-icon=false]:pr-11'
         ],
         label: [
           'text-xs',
@@ -316,11 +315,9 @@ const input = tv({
         icons: [
           'text-base'
         ],
-        rightIconsContainer: [
-          'gap-1'
-        ],
         clearIcon: [
-          'text-xs'
+          'text-xs',
+          'data-[right-icon=true]:right-11'
         ],
         chevrons: [
           'text-xs',
@@ -333,10 +330,9 @@ const input = tv({
           'pt-2.5',
           'text-sm',
           'data-[left-icon=true]:pl-12',
-          'data-[right-icon-count="1"]:pr-12',
-          'data-[right-icon-count="2"]:pr-19',
-          'data-[right-icon-count="3"]:pr-26',
-          'data-[right-icon-count="4"]:pr-33'
+          'data-[right-icon=true]:data-[clear-icon=false]:pr-12',
+          'data-[right-icon=true]:data-[clear-icon=true]:pr-19',
+          'data-[clear-icon=true]:data-[right-icon=false]:pr-12'
         ],
         label: [
           'text-sm',
@@ -348,11 +344,9 @@ const input = tv({
         icons: [
           'text-xl'
         ],
-        rightIconsContainer: [
-          'gap-1.5'
-        ],
         clearIcon: [
-          'text-sm'
+          'text-sm',
+          'data-[right-icon=true]:right-12'
         ],
         chevrons: [
           'text-sm',
@@ -365,10 +359,9 @@ const input = tv({
           'pt-3',
           'text-base',
           'data-[left-icon=true]:pl-13',
-          'data-[right-icon-count="1"]:pr-13',
-          'data-[right-icon-count="2"]:pr-21',
-          'data-[right-icon-count="3"]:pr-29',
-          'data-[right-icon-count="4"]:pr-37'
+          'data-[right-icon=true]:data-[clear-icon=false]:pr-13',
+          'data-[right-icon=true]:data-[clear-icon=true]:pr-21',
+          'data-[clear-icon=true]:data-[right-icon=false]:pr-13'
         ],
         label: [
           'text-base',
@@ -380,11 +373,9 @@ const input = tv({
         icons: [
           'text-2xl'
         ],
-        rightIconsContainer: [
-          'gap-2'
-        ],
         clearIcon: [
-          'text-base'
+          'text-base',
+          'data-[right-icon=true]:right-13'
         ],
         chevrons: [
           'text-base',
@@ -397,10 +388,9 @@ const input = tv({
           'pt-4',
           'text-lg',
           'data-[left-icon=true]:pl-14',
-          'data-[right-icon-count="1"]:pr-14',
-          'data-[right-icon-count="2"]:pr-23',
-          'data-[right-icon-count="3"]:pr-32',
-          'data-[right-icon-count="4"]:pr-41'
+          'data-[right-icon=true]:data-[clear-icon=false]:pr-14',
+          'data-[right-icon=true]:data-[clear-icon=true]:pr-23',
+          'data-[clear-icon=true]:data-[right-icon=false]:pr-14'
         ],
         label: [
           'text-lg',
@@ -412,11 +402,9 @@ const input = tv({
         icons: [
           'text-[28px]'
         ],
-        rightIconsContainer: [
-          'gap-2.5'
-        ],
         clearIcon: [
-          'text-lg'
+          'text-lg',
+          'data-[right-icon=true]:right-14'
         ],
         chevrons: [
           'text-lg',
@@ -440,7 +428,13 @@ const input = tv({
         leftIcon: [
           'left-4'
         ],
-        rightIconsContainer: [
+        rightIcon: [
+          'right-4'
+        ],
+        clearIcon: [
+          'right-4'
+        ],
+        numberArrows: [
           'right-4'
         ],
         helper: [
@@ -493,13 +487,15 @@ const input = tv({
       class: {
         input: [
           'data-[left-icon=true]:pl-13',
-          'data-[right-icon-count="1"]:pr-13',
-          'data-[right-icon-count="2"]:pr-19',
-          'data-[right-icon-count="3"]:pr-25',
-          'data-[right-icon-count="4"]:pr-31'
+          'data-[right-icon=true]:data-[clear-icon=false]:pr-13',
+          'data-[right-icon=true]:data-[clear-icon=true]:pr-19',
+          'data-[clear-icon=true]:data-[right-icon=false]:pr-13'
         ],
         label: [
           'peer-data-[left-icon=true]:left-13'
+        ],
+        clearIcon: [
+          'data-[right-icon=true]:right-13'
         ]
       }
     },
@@ -510,13 +506,15 @@ const input = tv({
       class: {
         input: [
           'data-[left-icon=true]:pl-14',
-          'data-[right-icon-count="1"]:pr-14',
-          'data-[right-icon-count="2"]:pr-21',
-          'data-[right-icon-count="3"]:pr-28',
-          'data-[right-icon-count="4"]:pr-35'
+          'data-[right-icon=true]:data-[clear-icon=false]:pr-14',
+          'data-[right-icon=true]:data-[clear-icon=true]:pr-21',
+          'data-[clear-icon=true]:data-[right-icon=false]:pr-14'
         ],
         label: [
           'peer-data-[left-icon=true]:left-14'
+        ],
+        clearIcon: [
+          'data-[right-icon=true]:right-14'
         ]
       }
     },
@@ -527,13 +525,15 @@ const input = tv({
       class: {
         input: [
           'data-[left-icon=true]:pl-15',
-          'data-[right-icon-count="1"]:pr-15',
-          'data-[right-icon-count="2"]:pr-23',
-          'data-[right-icon-count="3"]:pr-31',
-          'data-[right-icon-count="4"]:pr-39'
+          'data-[right-icon=true]:data-[clear-icon=false]:pr-15',
+          'data-[right-icon=true]:data-[clear-icon=true]:pr-23',
+          'data-[clear-icon=true]:data-[right-icon=false]:pr-15'
         ],
         label: [
           'peer-data-[left-icon=true]:left-15'
+        ],
+        clearIcon: [
+          'data-[right-icon=true]:right-15'
         ]
       }
     },
@@ -544,13 +544,127 @@ const input = tv({
       class: {
         input: [
           'data-[left-icon=true]:pl-16',
-          'data-[right-icon-count="1"]:pr-16',
-          'data-[right-icon-count="2"]:pr-25',
-          'data-[right-icon-count="3"]:pr-34',
-          'data-[right-icon-count="4"]:pr-43'
+          'data-[right-icon=true]:data-[clear-icon=false]:pr-16',
+          'data-[right-icon=true]:data-[clear-icon=true]:pr-25',
+          'data-[clear-icon=true]:data-[right-icon=false]:pr-16'
         ],
         label: [
           'peer-data-[left-icon=true]:left-16'
+        ],
+        clearIcon: [
+          'data-[right-icon=true]:right-16'
+        ]
+      }
+    },
+    {
+      type: 'number',
+      shape: ['soft', 'square'],
+      size: 'xs',
+      class: {
+        rightIcon: [
+          'data-[chevron-icons=true]:right-7'
+        ],
+        clearIcon: [
+          'data-[chevron-icons=true]:data-[right-icon=true]:right-13',
+          'data-[right-icon=false]:data-[chevron-icons=true]:right-7'
+        ]
+      }
+    },
+    {
+      type: 'number',
+      shape: ['soft', 'square'],
+      size: 'sm',
+      class: {
+        rightIcon: [
+          'data-[chevron-icons=true]:right-7.5'
+        ],
+        clearIcon: [
+          'data-[chevron-icons=true]:data-[right-icon=true]:right-14.5',
+          'data-[right-icon=false]:data-[chevron-icons=true]:right-7.5'
+        ]
+      }
+    },
+    {
+      type: 'number',
+      shape: ['soft', 'square'],
+      size: 'md',
+      class: {
+        rightIcon: [
+          'data-[chevron-icons=true]:right-8'
+        ],
+        clearIcon: [
+          'data-[chevron-icons=true]:data-[right-icon=true]:right-16',
+          'data-[right-icon=false]:data-[chevron-icons=true]:right-8'
+        ]
+      }
+    },
+    {
+      type: 'number',
+      shape: ['soft', 'square'],
+      size: 'lg',
+      class: {
+        rightIcon: [
+          'data-[chevron-icons=true]:right-8.5'
+        ],
+        clearIcon: [
+          'data-[chevron-icons=true]:data-[right-icon=true]:right-17.5',
+          'data-[right-icon=false]:data-[chevron-icons=true]:right-8.5'
+        ]
+      }
+    },
+    {
+      type: 'number',
+      shape: 'rounded',
+      size: 'xs',
+      class: {
+        rightIcon: [
+          'data-[chevron-icons=true]:right-9'
+        ],
+        clearIcon: [
+          'data-[chevron-icons=true]:data-[right-icon=true]:right-15',
+          'data-[right-icon=false]:data-[chevron-icons=true]:right-9'
+        ]
+      }
+    },
+    {
+      type: 'number',
+      shape: 'rounded',
+      size: 'sm',
+      class: {
+        rightIcon: [
+          'data-[chevron-icons=true]:right-9.5'
+        ],
+        clearIcon: [
+          'data-[chevron-icons=true]:data-[right-icon=true]:right-16.5',
+          'data-[right-icon=false]:data-[chevron-icons=true]:right-9.5'
+        ]
+      }
+    },
+    {
+      type: 'number',
+      shape: 'rounded',
+      size: 'md',
+      class: {
+        rightIcon: [
+          'data-[chevron-icons=true]:right-10'
+        ],
+        clearIcon: [
+          'data-[chevron-icons=true]:data-[right-icon=true]:right-18',
+          'data-[right-icon=false]:data-[chevron-icons=true]:right-10'
+        ]
+      }
+    },
+    {
+      type: 'number',
+      shape: 'rounded',
+      size: 'lg',
+      class: {
+        rightIcon: [
+          'data-[chevron-icons=true]:right-10.5'
+        ],
+        clearIcon: [
+          'data-[chevron-icons=true]:data-[right-icon=true]:right-19.5',
+          'data-[right-icon=false]:data-[chevron-icons=true]:right-10.5'
         ]
       }
     },

--- a/packages/valko-ui-components/src/styles/Input.styles.ts
+++ b/packages/valko-ui-components/src/styles/Input.styles.ts
@@ -68,9 +68,11 @@ const input = tv({
       '-translate-y-1/2'
     ],
     rightIcon: [
+      'vk-right-icon',
       'right-3'
     ],
     leftIcon: [
+      'vk-left-icon',
       'left-3'
     ],
     clearIcon: [

--- a/packages/valko-ui-components/src/styles/Input.styles.ts
+++ b/packages/valko-ui-components/src/styles/Input.styles.ts
@@ -62,26 +62,29 @@ const input = tv({
       'vk-input__icons',
       'cursor-pointer',
       'text-on-surface-variant',
+      'transition-all'
+    ],
+    rightIconsContainer: [
+      'vk-input__right-icons',
       'absolute',
-      'transition-all',
+      'right-3',
       'top-1/2',
-      '-translate-y-1/2'
+      '-translate-y-1/2',
+      'flex',
+      'items-center'
     ],
-    rightIcon: [
-      'right-3'
-    ],
+    rightIcon: [],
     leftIcon: [
+      'absolute',
+      'top-1/2',
+      '-translate-y-1/2',
       'left-3'
     ],
     clearIcon: [
       'vk-input__clear-icon',
       'text-on-surface-variant',
       'cursor-pointer',
-      'absolute',
-      'transition-all',
-      'top-1/2',
-      '-translate-y-1/2',
-      'right-3'
+      'transition-all'
     ],
     numberArrows: [
       'vk-input__number-arrows',
@@ -89,13 +92,10 @@ const input = tv({
       'flex',
       'flex-col',
       'gap-1',
-      'absolute',
-      'right-3',
-      'top-1/2',
-      '-translate-y-1/2',
       'cursor-pointer'
     ],
-    chevrons: []
+    chevrons: [],
+    suffixIcon: []
   },
   variants: {
     variant: {
@@ -301,9 +301,10 @@ const input = tv({
           'pt-2',
           'text-xs',
           'data-[left-icon=true]:pl-11',
-          'data-[right-icon=true]:data-[clear-icon=false]:pr-11',
-          'data-[right-icon=true]:data-[clear-icon=true]:pr-17',
-          'data-[clear-icon=true]:data-[right-icon=false]:pr-11'
+          'data-[right-icon-count="1"]:pr-11',
+          'data-[right-icon-count="2"]:pr-17',
+          'data-[right-icon-count="3"]:pr-23',
+          'data-[right-icon-count="4"]:pr-29'
         ],
         label: [
           'text-xs',
@@ -315,9 +316,11 @@ const input = tv({
         icons: [
           'text-base'
         ],
+        rightIconsContainer: [
+          'gap-1'
+        ],
         clearIcon: [
-          'text-xs',
-          'data-[right-icon=true]:right-11'
+          'text-xs'
         ],
         chevrons: [
           'text-xs',
@@ -330,9 +333,10 @@ const input = tv({
           'pt-2.5',
           'text-sm',
           'data-[left-icon=true]:pl-12',
-          'data-[right-icon=true]:data-[clear-icon=false]:pr-12',
-          'data-[right-icon=true]:data-[clear-icon=true]:pr-19',
-          'data-[clear-icon=true]:data-[right-icon=false]:pr-12'
+          'data-[right-icon-count="1"]:pr-12',
+          'data-[right-icon-count="2"]:pr-19',
+          'data-[right-icon-count="3"]:pr-26',
+          'data-[right-icon-count="4"]:pr-33'
         ],
         label: [
           'text-sm',
@@ -344,9 +348,11 @@ const input = tv({
         icons: [
           'text-xl'
         ],
+        rightIconsContainer: [
+          'gap-1.5'
+        ],
         clearIcon: [
-          'text-sm',
-          'data-[right-icon=true]:right-12'
+          'text-sm'
         ],
         chevrons: [
           'text-sm',
@@ -359,9 +365,10 @@ const input = tv({
           'pt-3',
           'text-base',
           'data-[left-icon=true]:pl-13',
-          'data-[right-icon=true]:data-[clear-icon=false]:pr-13',
-          'data-[right-icon=true]:data-[clear-icon=true]:pr-21',
-          'data-[clear-icon=true]:data-[right-icon=false]:pr-13'
+          'data-[right-icon-count="1"]:pr-13',
+          'data-[right-icon-count="2"]:pr-21',
+          'data-[right-icon-count="3"]:pr-29',
+          'data-[right-icon-count="4"]:pr-37'
         ],
         label: [
           'text-base',
@@ -373,9 +380,11 @@ const input = tv({
         icons: [
           'text-2xl'
         ],
+        rightIconsContainer: [
+          'gap-2'
+        ],
         clearIcon: [
-          'text-base',
-          'data-[right-icon=true]:right-13'
+          'text-base'
         ],
         chevrons: [
           'text-base',
@@ -388,9 +397,10 @@ const input = tv({
           'pt-4',
           'text-lg',
           'data-[left-icon=true]:pl-14',
-          'data-[right-icon=true]:data-[clear-icon=false]:pr-14',
-          'data-[right-icon=true]:data-[clear-icon=true]:pr-23',
-          'data-[clear-icon=true]:data-[right-icon=false]:pr-14'
+          'data-[right-icon-count="1"]:pr-14',
+          'data-[right-icon-count="2"]:pr-23',
+          'data-[right-icon-count="3"]:pr-32',
+          'data-[right-icon-count="4"]:pr-41'
         ],
         label: [
           'text-lg',
@@ -402,9 +412,11 @@ const input = tv({
         icons: [
           'text-[28px]'
         ],
+        rightIconsContainer: [
+          'gap-2.5'
+        ],
         clearIcon: [
-          'text-lg',
-          'data-[right-icon=true]:right-14'
+          'text-lg'
         ],
         chevrons: [
           'text-lg',
@@ -428,13 +440,7 @@ const input = tv({
         leftIcon: [
           'left-4'
         ],
-        rightIcon: [
-          'right-4'
-        ],
-        clearIcon: [
-          'right-4'
-        ],
-        numberArrows: [
+        rightIconsContainer: [
           'right-4'
         ],
         helper: [
@@ -487,15 +493,13 @@ const input = tv({
       class: {
         input: [
           'data-[left-icon=true]:pl-13',
-          'data-[right-icon=true]:data-[clear-icon=false]:pr-13',
-          'data-[right-icon=true]:data-[clear-icon=true]:pr-19',
-          'data-[clear-icon=true]:data-[right-icon=false]:pr-13'
+          'data-[right-icon-count="1"]:pr-13',
+          'data-[right-icon-count="2"]:pr-19',
+          'data-[right-icon-count="3"]:pr-25',
+          'data-[right-icon-count="4"]:pr-31'
         ],
         label: [
           'peer-data-[left-icon=true]:left-13'
-        ],
-        clearIcon: [
-          'data-[right-icon=true]:right-13'
         ]
       }
     },
@@ -506,15 +510,13 @@ const input = tv({
       class: {
         input: [
           'data-[left-icon=true]:pl-14',
-          'data-[right-icon=true]:data-[clear-icon=false]:pr-14',
-          'data-[right-icon=true]:data-[clear-icon=true]:pr-21',
-          'data-[clear-icon=true]:data-[right-icon=false]:pr-14'
+          'data-[right-icon-count="1"]:pr-14',
+          'data-[right-icon-count="2"]:pr-21',
+          'data-[right-icon-count="3"]:pr-28',
+          'data-[right-icon-count="4"]:pr-35'
         ],
         label: [
           'peer-data-[left-icon=true]:left-14'
-        ],
-        clearIcon: [
-          'data-[right-icon=true]:right-14'
         ]
       }
     },
@@ -525,15 +527,13 @@ const input = tv({
       class: {
         input: [
           'data-[left-icon=true]:pl-15',
-          'data-[right-icon=true]:data-[clear-icon=false]:pr-15',
-          'data-[right-icon=true]:data-[clear-icon=true]:pr-23',
-          'data-[clear-icon=true]:data-[right-icon=false]:pr-15'
+          'data-[right-icon-count="1"]:pr-15',
+          'data-[right-icon-count="2"]:pr-23',
+          'data-[right-icon-count="3"]:pr-31',
+          'data-[right-icon-count="4"]:pr-39'
         ],
         label: [
           'peer-data-[left-icon=true]:left-15'
-        ],
-        clearIcon: [
-          'data-[right-icon=true]:right-15'
         ]
       }
     },
@@ -544,127 +544,13 @@ const input = tv({
       class: {
         input: [
           'data-[left-icon=true]:pl-16',
-          'data-[right-icon=true]:data-[clear-icon=false]:pr-16',
-          'data-[right-icon=true]:data-[clear-icon=true]:pr-25',
-          'data-[clear-icon=true]:data-[right-icon=false]:pr-16'
+          'data-[right-icon-count="1"]:pr-16',
+          'data-[right-icon-count="2"]:pr-25',
+          'data-[right-icon-count="3"]:pr-34',
+          'data-[right-icon-count="4"]:pr-43'
         ],
         label: [
           'peer-data-[left-icon=true]:left-16'
-        ],
-        clearIcon: [
-          'data-[right-icon=true]:right-16'
-        ]
-      }
-    },
-    {
-      type: 'number',
-      shape: ['soft', 'square'],
-      size: 'xs',
-      class: {
-        rightIcon: [
-          'data-[chevron-icons=true]:right-7'
-        ],
-        clearIcon: [
-          'data-[chevron-icons=true]:data-[right-icon=true]:right-13',
-          'data-[right-icon=false]:data-[chevron-icons=true]:right-7'
-        ]
-      }
-    },
-    {
-      type: 'number',
-      shape: ['soft', 'square'],
-      size: 'sm',
-      class: {
-        rightIcon: [
-          'data-[chevron-icons=true]:right-7.5'
-        ],
-        clearIcon: [
-          'data-[chevron-icons=true]:data-[right-icon=true]:right-14.5',
-          'data-[right-icon=false]:data-[chevron-icons=true]:right-7.5'
-        ]
-      }
-    },
-    {
-      type: 'number',
-      shape: ['soft', 'square'],
-      size: 'md',
-      class: {
-        rightIcon: [
-          'data-[chevron-icons=true]:right-8'
-        ],
-        clearIcon: [
-          'data-[chevron-icons=true]:data-[right-icon=true]:right-16',
-          'data-[right-icon=false]:data-[chevron-icons=true]:right-8'
-        ]
-      }
-    },
-    {
-      type: 'number',
-      shape: ['soft', 'square'],
-      size: 'lg',
-      class: {
-        rightIcon: [
-          'data-[chevron-icons=true]:right-8.5'
-        ],
-        clearIcon: [
-          'data-[chevron-icons=true]:data-[right-icon=true]:right-17.5',
-          'data-[right-icon=false]:data-[chevron-icons=true]:right-8.5'
-        ]
-      }
-    },
-    {
-      type: 'number',
-      shape: 'rounded',
-      size: 'xs',
-      class: {
-        rightIcon: [
-          'data-[chevron-icons=true]:right-9'
-        ],
-        clearIcon: [
-          'data-[chevron-icons=true]:data-[right-icon=true]:right-15',
-          'data-[right-icon=false]:data-[chevron-icons=true]:right-9'
-        ]
-      }
-    },
-    {
-      type: 'number',
-      shape: 'rounded',
-      size: 'sm',
-      class: {
-        rightIcon: [
-          'data-[chevron-icons=true]:right-9.5'
-        ],
-        clearIcon: [
-          'data-[chevron-icons=true]:data-[right-icon=true]:right-16.5',
-          'data-[right-icon=false]:data-[chevron-icons=true]:right-9.5'
-        ]
-      }
-    },
-    {
-      type: 'number',
-      shape: 'rounded',
-      size: 'md',
-      class: {
-        rightIcon: [
-          'data-[chevron-icons=true]:right-10'
-        ],
-        clearIcon: [
-          'data-[chevron-icons=true]:data-[right-icon=true]:right-18',
-          'data-[right-icon=false]:data-[chevron-icons=true]:right-10'
-        ]
-      }
-    },
-    {
-      type: 'number',
-      shape: 'rounded',
-      size: 'lg',
-      class: {
-        rightIcon: [
-          'data-[chevron-icons=true]:right-10.5'
-        ],
-        clearIcon: [
-          'data-[chevron-icons=true]:data-[right-icon=true]:right-19.5',
-          'data-[right-icon=false]:data-[chevron-icons=true]:right-10.5'
         ]
       }
     },

--- a/packages/valko-ui-components/src/styles/Select.styles.ts
+++ b/packages/valko-ui-components/src/styles/Select.styles.ts
@@ -49,14 +49,19 @@ const select = tv({
       'data-[shape=soft]:rounded-lg',
       'data-[shape=square]:rounded-none'
     ],
-    icon: [
-      'block',
+    chevronIcon: [
+      'absolute',
+      'right-2',
+      'top-1/2',
+      '-translate-y-1/2',
       'transition-transform',
       'duration-200',
       'ease-out',
       'data-[open=true]:rotate-180',
       'cursor-pointer'
-    ]
+    ],
+    rightIcon: [],
+    clearIcon: []
   },
   variants: {
     color: {
@@ -215,25 +220,143 @@ const select = tv({
       xs: {
         item: [
           'text-xs'
+        ],
+        chevronIcon: [
+          'text-base'
         ]
       },
       sm: {
         item: [
           'text-sm'
+        ],
+        chevronIcon: [
+          'text-xl'
         ]
       },
       md: {
         item: [
           'text-md'
+        ],
+        chevronIcon: [
+          'text-2xl'
         ]
       },
       lg: {
         item: [
           'text-lg'
+        ],
+        chevronIcon: [
+          'text-[28px]'
         ]
       }
     }
-  }
+  },
+  compoundVariants: [
+    {
+      shape: ['soft', 'square'],
+      size: 'xs',
+      class: {
+        rightIcon: [
+          'right-7'
+        ],
+        clearIcon: [
+          'right-7',
+          'data-[right-icon=true]:right-13'
+        ]
+      }
+    },
+    {
+      shape: ['soft', 'square'],
+      size: 'sm',
+      class: {
+        rightIcon: [
+          'right-7.5'
+        ],
+        clearIcon: [
+          'right-7.5',
+          'data-[right-icon=true]:right-14.5'
+        ]
+      }
+    },
+    {
+      shape: ['soft', 'square'],
+      size: 'md',
+      class: {
+        rightIcon: [
+          'right-8'
+        ],
+        clearIcon: [
+          'right-8',
+          'data-[right-icon=true]:right-16'
+        ]
+      }
+    },
+    {
+      shape: ['soft', 'square'],
+      size: 'lg',
+      class: {
+        rightIcon: [
+          'right-8.5'
+        ],
+        clearIcon: [
+          'right-8.5',
+          'data-[right-icon=true]:right-17.5'
+        ]
+      }
+    },
+    {
+      shape: 'rounded',
+      size: 'xs',
+      class: {
+        rightIcon: [
+          'right-9'
+        ],
+        clearIcon: [
+          'right-9',
+          'data-[right-icon=true]:right-15'
+        ]
+      }
+    },
+    {
+      shape: 'rounded',
+      size: 'sm',
+      class: {
+        rightIcon: [
+          'right-9.5'
+        ],
+        clearIcon: [
+          'right-9.5',
+          'data-[right-icon=true]:right-16.5'
+        ]
+      }
+    },
+    {
+      shape: 'rounded',
+      size: 'md',
+      class: {
+        rightIcon: [
+          'right-10'
+        ],
+        clearIcon: [
+          'right-10',
+          'data-[right-icon=true]:right-18'
+        ]
+      }
+    },
+    {
+      shape: 'rounded',
+      size: 'lg',
+      class: {
+        rightIcon: [
+          'right-10.5'
+        ],
+        clearIcon: [
+          'right-10.5',
+          'data-[right-icon=true]:right-19.5'
+        ]
+      }
+    }
+  ]
 })
 
 export default select

--- a/packages/valko-ui-components/src/styles/Select.styles.ts
+++ b/packages/valko-ui-components/src/styles/Select.styles.ts
@@ -58,7 +58,8 @@ const select = tv({
       'duration-200',
       'ease-out',
       'data-[open=true]:rotate-180',
-      'cursor-pointer'
+      'cursor-pointer',
+      'data-[helpertext=true]:top-[35%]'
     ],
     rightIcon: [],
     clearIcon: []

--- a/packages/valko-ui-components/src/styles/Select.styles.ts
+++ b/packages/valko-ui-components/src/styles/Select.styles.ts
@@ -49,20 +49,13 @@ const select = tv({
       'data-[shape=soft]:rounded-lg',
       'data-[shape=square]:rounded-none'
     ],
-    chevronIcon: [
-      'absolute',
-      'right-2',
-      'top-1/2',
-      '-translate-y-1/2',
+    suffixIcon: [
+      'block',
       'transition-transform',
       'duration-200',
       'ease-out',
-      'data-[open=true]:rotate-180',
-      'cursor-pointer',
-      'data-[helpertext=true]:top-[35%]'
-    ],
-    rightIcon: [],
-    clearIcon: []
+      'data-[open=true]:rotate-180'
+    ]
   },
   variants: {
     color: {
@@ -221,143 +214,25 @@ const select = tv({
       xs: {
         item: [
           'text-xs'
-        ],
-        chevronIcon: [
-          'text-base'
         ]
       },
       sm: {
         item: [
           'text-sm'
-        ],
-        chevronIcon: [
-          'text-xl'
         ]
       },
       md: {
         item: [
           'text-md'
-        ],
-        chevronIcon: [
-          'text-2xl'
         ]
       },
       lg: {
         item: [
           'text-lg'
-        ],
-        chevronIcon: [
-          'text-[28px]'
         ]
       }
     }
-  },
-  compoundVariants: [
-    {
-      shape: ['soft', 'square'],
-      size: 'xs',
-      class: {
-        rightIcon: [
-          'right-7'
-        ],
-        clearIcon: [
-          'right-7',
-          'data-[right-icon=true]:right-13'
-        ]
-      }
-    },
-    {
-      shape: ['soft', 'square'],
-      size: 'sm',
-      class: {
-        rightIcon: [
-          'right-7.5'
-        ],
-        clearIcon: [
-          'right-7.5',
-          'data-[right-icon=true]:right-14.5'
-        ]
-      }
-    },
-    {
-      shape: ['soft', 'square'],
-      size: 'md',
-      class: {
-        rightIcon: [
-          'right-8'
-        ],
-        clearIcon: [
-          'right-8',
-          'data-[right-icon=true]:right-16'
-        ]
-      }
-    },
-    {
-      shape: ['soft', 'square'],
-      size: 'lg',
-      class: {
-        rightIcon: [
-          'right-8.5'
-        ],
-        clearIcon: [
-          'right-8.5',
-          'data-[right-icon=true]:right-17.5'
-        ]
-      }
-    },
-    {
-      shape: 'rounded',
-      size: 'xs',
-      class: {
-        rightIcon: [
-          'right-9'
-        ],
-        clearIcon: [
-          'right-9',
-          'data-[right-icon=true]:right-15'
-        ]
-      }
-    },
-    {
-      shape: 'rounded',
-      size: 'sm',
-      class: {
-        rightIcon: [
-          'right-9.5'
-        ],
-        clearIcon: [
-          'right-9.5',
-          'data-[right-icon=true]:right-16.5'
-        ]
-      }
-    },
-    {
-      shape: 'rounded',
-      size: 'md',
-      class: {
-        rightIcon: [
-          'right-10'
-        ],
-        clearIcon: [
-          'right-10',
-          'data-[right-icon=true]:right-18'
-        ]
-      }
-    },
-    {
-      shape: 'rounded',
-      size: 'lg',
-      class: {
-        rightIcon: [
-          'right-10.5'
-        ],
-        clearIcon: [
-          'right-10.5',
-          'data-[right-icon=true]:right-19.5'
-        ]
-      }
-    }
-  ]
+  }
 })
 
 export default select

--- a/packages/valko-ui-components/src/styles/Select.styles.ts
+++ b/packages/valko-ui-components/src/styles/Select.styles.ts
@@ -49,12 +49,13 @@ const select = tv({
       'data-[shape=soft]:rounded-lg',
       'data-[shape=square]:rounded-none'
     ],
-    suffixIcon: [
+    icon: [
       'block',
       'transition-transform',
       'duration-200',
       'ease-out',
-      'data-[open=true]:rotate-180'
+      'data-[open=true]:rotate-180',
+      'cursor-pointer'
     ]
   },
   variants: {

--- a/packages/valko-ui-components/src/types/Input.ts
+++ b/packages/valko-ui-components/src/types/Input.ts
@@ -17,5 +17,6 @@ export interface InputProps extends Sizes, ColorsWithSurface, Variants, Shapes, 
   loading?: boolean;
   readonly?: boolean;
   clearable?: boolean;
+  iconClickFocus?: boolean;
   styleSlots?: Partial<InputSlots>;
 }

--- a/packages/valko-ui-components/src/types/Input.ts
+++ b/packages/valko-ui-components/src/types/Input.ts
@@ -17,6 +17,7 @@ export interface InputProps extends Sizes, ColorsWithSurface, Variants, Shapes, 
   loading?: boolean;
   readonly?: boolean;
   clearable?: boolean;
+  forceClearable?: boolean;
   disableIconClickFocus?: boolean;
   styleSlots?: Partial<InputSlots>;
 }

--- a/packages/valko-ui-components/src/types/Input.ts
+++ b/packages/valko-ui-components/src/types/Input.ts
@@ -17,6 +17,6 @@ export interface InputProps extends Sizes, ColorsWithSurface, Variants, Shapes, 
   loading?: boolean;
   readonly?: boolean;
   clearable?: boolean;
-  iconClickFocus?: boolean;
+  disableIconClickFocus?: boolean;
   styleSlots?: Partial<InputSlots>;
 }

--- a/packages/valko-ui-components/src/types/Input.ts
+++ b/packages/valko-ui-components/src/types/Input.ts
@@ -18,5 +18,6 @@ export interface InputProps extends Sizes, ColorsWithSurface, Variants, Shapes, 
   readonly?: boolean;
   clearable?: boolean;
   forceClearable?: boolean;
+  disableIconClickFocus?: boolean;
   styleSlots?: Partial<InputSlots>;
 }

--- a/packages/valko-ui-components/src/types/Input.ts
+++ b/packages/valko-ui-components/src/types/Input.ts
@@ -18,6 +18,5 @@ export interface InputProps extends Sizes, ColorsWithSurface, Variants, Shapes, 
   readonly?: boolean;
   clearable?: boolean;
   forceClearable?: boolean;
-  disableIconClickFocus?: boolean;
   styleSlots?: Partial<InputSlots>;
 }

--- a/packages/valko-ui-components/src/types/Select.ts
+++ b/packages/valko-ui-components/src/types/Select.ts
@@ -15,6 +15,5 @@ export interface SelectProps extends DefaultComponent, Omit<AriaAttributes, 'ari
   disabled?: boolean;
   readonly?: boolean;
   clearable?: boolean;
-  disableIconClickFocus?: boolean;
   styleSlots?: Partial<SelectSlots>;
 }

--- a/packages/valko-ui-components/src/types/Select.ts
+++ b/packages/valko-ui-components/src/types/Select.ts
@@ -15,5 +15,6 @@ export interface SelectProps extends DefaultComponent, Omit<AriaAttributes, 'ari
   disabled?: boolean;
   readonly?: boolean;
   clearable?: boolean;
+  disableIconClickFocus?: boolean;
   styleSlots?: Partial<SelectSlots>;
 }

--- a/packages/valko-ui-docs/app/pages/docs/(forms)/input.vue
+++ b/packages/valko-ui-docs/app/pages/docs/(forms)/input.vue
@@ -19,7 +19,8 @@ const form = ref<InputProps>({
   helpertext: 'Helpertext',
   disabled: false,
   readonly: false,
-  clearable: false
+  clearable: false,
+  forceClearable: false
 })
 
 const iconsInForm = ref({
@@ -29,7 +30,8 @@ const iconsInForm = ref({
 })
 
 const inputStates = reactive<Record<string, string>>({
-  readonly: 'Example readonly.'
+  readonly: 'Example readonly.',
+  forceClearable: 'Try clearing me!'
 })
 
 const apiData: PropData[] = [
@@ -92,6 +94,15 @@ const apiData: PropData[] = [
     prop: 'clearable',
     required: false,
     description: 'Whether the Input is rounded or not.',
+    values: 'boolean',
+    default: 'false',
+    apiType: 'primitive'
+  },
+  {
+    key: 'forceClearableProp',
+    prop: 'forceClearable',
+    required: false,
+    description: 'Allows clearing the input even when readonly is true. Used by components like Select that set the input as readonly but still need clear functionality.',
     values: 'boolean',
     default: 'false',
     apiType: 'primitive'
@@ -478,6 +489,8 @@ const styles = {
         :max="form.max"
         :step="form.step"
         :clearable="form.clearable"
+        :force-clearable="form.forceClearable"
+        :disable-icon-click-focus="form.disableIconClickFocus"
         @left-icon-click="useNotification({ text: 'Left Icon!!', color: 'surface' })"
         @right-icon-click="useNotification({ text: 'Right Icon!!', color: 'surface' })"
         @suffix-icon-click="useNotification({ text: 'Suffix Icon!!', color: 'surface' })"
@@ -576,6 +589,10 @@ const styles = {
       <vk-checkbox
         v-model="form.clearable"
         label="Clearable"
+      />
+      <vk-checkbox
+        v-model="form.forceClearable"
+        label="Force Clearable"
       />
       <vk-checkbox
         v-model="iconsInForm.left"
@@ -683,6 +700,17 @@ const styles = {
         </template>
       </example-section>
 
+      <example-section title="Helpertext">
+        <vk-input
+          label="With Helpertext"
+          helpertext="This is a helpful hint."
+        />
+
+        <template #code>
+          <code-block :code="generateSnippet<string>('helpertext', { values: ['This is a helpful hint.'] })" />
+        </template>
+      </example-section>
+
       <example-section title="Readonly">
         <vk-input
           v-model="inputStates['readonly']"
@@ -703,6 +731,36 @@ const styles = {
 
         <template #code>
           <code-block :code="generateSnippet<boolean>('clearable', { values: [true] })" />
+        </template>
+      </example-section>
+
+      <example-section title="Force Clearable">
+        <vk-input
+          v-model="inputStates['forceClearable']"
+          readonly
+          force-clearable
+          clearable
+          label="Force Clearable"
+          @clear="resetForceClearable"
+        />
+
+        <template #code>
+          <code-block :code="generateSnippet<boolean>('forceClearable', { values: [true], extraProps: 'readonly clearable' })" />
+        </template>
+      </example-section>
+
+      <example-section title="Disable Icon Click Focus">
+        <vk-input
+          disable-icon-click-focus
+          label="Disable Icon Click Focus"
+        >
+          <template #left-icon>
+            <vk-icon name="home" />
+          </template>
+        </vk-input>
+
+        <template #code>
+          <code-block :code="generateSnippet<boolean>('disableIconClickFocus', { values: [true] })" />
         </template>
       </example-section>
 

--- a/packages/valko-ui-docs/app/pages/docs/(forms)/input.vue
+++ b/packages/valko-ui-docs/app/pages/docs/(forms)/input.vue
@@ -168,6 +168,14 @@ const apiData: PropData[] = [
     apiType: 'custom-string'
   },
   {
+    key: 'iconClickFocusProp',
+    prop: 'iconClickFocus',
+    required: false,
+    description: 'Whether the input should focus when the icon is clicked.',
+    values: 'true, false',
+    default: 'true'
+  },
+  {
     key: 'ariaLabelProp',
     prop: 'ariaLabel',
     required: false,

--- a/packages/valko-ui-docs/app/pages/docs/(forms)/input.vue
+++ b/packages/valko-ui-docs/app/pages/docs/(forms)/input.vue
@@ -20,7 +20,8 @@ const form = ref<InputProps>({
   disabled: false,
   readonly: false,
   clearable: false,
-  forceClearable: false
+  forceClearable: false,
+  disableIconClickFocus: false
 })
 
 const iconsInForm = ref({
@@ -66,7 +67,7 @@ const apiData: PropData[] = [
     prop: 'cursor',
     required: false,
     description: 'The displayed cursor type when hovering the input.',
-    values: 'cursor | text',
+    values: 'pointer | text',
     default: 'text',
     apiType: 'custom-string'
   },
@@ -92,7 +93,7 @@ const apiData: PropData[] = [
     key: 'clearableProp',
     prop: 'clearable',
     required: false,
-    description: 'Whether the Input is rounded or not.',
+    description: 'Displays a clear icon that resets the input value when clicked.',
     values: 'boolean',
     default: 'false',
     apiType: 'primitive'
@@ -110,7 +111,7 @@ const apiData: PropData[] = [
     key: 'modelValueProp',
     prop: 'modelValue',
     required: false,
-    description: 'The v-model for the Input',
+    description: 'The v-model for the Input.',
     values: 'string, number',
     default: '',
     apiType: 'primitive'
@@ -119,7 +120,7 @@ const apiData: PropData[] = [
     key: 'minProp',
     prop: 'min',
     required: false,
-    description: 'The min value for the Input in type number',
+    description: 'The minimum value for number inputs.',
     values: 'number',
     default: '-Infinity',
     apiType: 'primitive'
@@ -128,7 +129,7 @@ const apiData: PropData[] = [
     key: 'maxProp',
     prop: 'max',
     required: false,
-    description: 'The max value for the Input in type number',
+    description: 'The maximum value for number inputs.',
     values: 'number',
     default: 'Infinity',
     apiType: 'primitive'
@@ -137,7 +138,7 @@ const apiData: PropData[] = [
     key: 'stepProp',
     prop: 'step',
     required: false,
-    description: 'The step value for the Input in type number',
+    description: 'The increment/decrement step for number inputs.',
     values: 'number',
     default: '1',
     apiType: 'primitive'
@@ -146,7 +147,7 @@ const apiData: PropData[] = [
     key: 'readonlyProp',
     prop: 'readonly',
     required: false,
-    description: 'Wheter the Input is readonly or not',
+    description: 'Whether the Input is readonly or not.',
     values: 'boolean',
     default: 'false',
     apiType: 'primitive'
@@ -173,10 +174,19 @@ const apiData: PropData[] = [
     key: 'shapeProp',
     prop: 'shape',
     required: false,
-    description: 'The shape of the Input',
+    description: 'The shape of the Input.',
     values: 'rounded, soft, square',
     default: 'soft',
     apiType: 'custom-string'
+  },
+  {
+    key: 'disableIconClickFocusProp',
+    prop: 'disableIconClickFocus',
+    required: false,
+    description: 'Disables focusing the input when clicking on the icons.',
+    values: 'boolean',
+    default: 'false',
+    apiType: 'primitive'
   },
   {
     key: 'ariaLabelProp',
@@ -341,8 +351,8 @@ const emitData: EmitData[] = [
     key: 'updateModelValueEmit',
     event: 'update:modelValue',
     description: 'Emitted when the value of the input is updated.',
-    values: 'string',
-    type: '(value: string) => void',
+    values: 'string | number',
+    type: '(value: string | number) => void',
     apiType: 'primitive'
   },
   {
@@ -367,7 +377,7 @@ const emitData: EmitData[] = [
     description: 'Emitted when the input is cleared using the clearable icon.',
     values: '',
     type: '() => void',
-    apiType: 'function'
+    apiType: 'event'
   },
   {
     key: 'leftIconClickEmit',
@@ -375,7 +385,7 @@ const emitData: EmitData[] = [
     description: 'Emitted when the left icon of the input is clicked.',
     values: '',
     type: '() => void',
-    apiType: 'function'
+    apiType: 'event'
   },
   {
     key: 'rightIconClickEmit',
@@ -383,7 +393,7 @@ const emitData: EmitData[] = [
     description: 'Emitted when the right icon of the input is clicked.',
     values: '',
     type: '() => void',
-    apiType: 'function'
+    apiType: 'event'
   }
 ]
 
@@ -473,6 +483,7 @@ const resetForceClearableInput = () => setTimeout(() => { inputStates.forceClear
         :step="form.step"
         :clearable="form.clearable"
         :force-clearable="form.forceClearable"
+        :disable-icon-click-focus="form.disableIconClickFocus"
         @left-icon-click="useNotification({ text: 'Left Icon!!', color: 'surface' })"
         @right-icon-click="useNotification({ text: 'Right Icon!!', color: 'surface' })"
       >
@@ -568,6 +579,10 @@ const resetForceClearableInput = () => setTimeout(() => { inputStates.forceClear
       <vk-checkbox
         v-model="form.forceClearable"
         label="Force Clearable"
+      />
+      <vk-checkbox
+        v-model="form.disableIconClickFocus"
+        label="Disable Icon Click Focus"
       />
       <vk-checkbox
         v-model="iconsInForm.left"
@@ -717,6 +732,25 @@ const resetForceClearableInput = () => setTimeout(() => { inputStates.forceClear
 
         <template #code>
           <code-block :code="generateSnippet<boolean>('forceClearable', { values: [true], extraProps: 'readonly clearable' })" />
+        </template>
+      </example-section>
+
+      <example-section title="Disable Icon Click Focus">
+        <vk-input
+          label="Disable Icon Click Focus"
+          clearable
+          disable-icon-click-focus
+        >
+          <template #left-icon>
+            <vk-icon name="home" />
+          </template>
+          <template #right-icon>
+            <vk-icon name="home" />
+          </template>
+        </vk-input>
+
+        <template #code>
+          <code-block :code="generateSnippet<boolean>('disableIconClickFocus', { values: [true], extraProps: 'clearable' })" />
         </template>
       </example-section>
 

--- a/packages/valko-ui-docs/app/pages/docs/(forms)/input.vue
+++ b/packages/valko-ui-docs/app/pages/docs/(forms)/input.vue
@@ -24,7 +24,8 @@ const form = ref<InputProps>({
 
 const iconsInForm = ref({
   left: false,
-  right: false
+  right: false,
+  suffix: false
 })
 
 const inputStates = reactive<Record<string, string>>({
@@ -87,8 +88,8 @@ const apiData: PropData[] = [
     apiType: 'primitive'
   },
   {
-    key: 'roundedProp',
-    prop: 'rounded',
+    key: 'clearableProp',
+    prop: 'clearable',
     required: false,
     description: 'Whether the Input is rounded or not.',
     values: 'boolean',
@@ -144,7 +145,7 @@ const apiData: PropData[] = [
     key: 'labelProp',
     prop: 'label',
     required: false,
-    description: 'The label for the Input',
+    description: 'The label for the Input.',
     values: 'string',
     default: '',
     apiType: 'primitive'
@@ -153,7 +154,7 @@ const apiData: PropData[] = [
     key: 'helpertextProp',
     prop: 'helpertext',
     required: false,
-    description: 'A hint for the Input',
+    description: 'A hint for the Input.',
     values: 'string',
     default: '',
     apiType: 'primitive'
@@ -168,12 +169,13 @@ const apiData: PropData[] = [
     apiType: 'custom-string'
   },
   {
-    key: 'iconClickFocusProp',
-    prop: 'iconClickFocus',
+    key: 'disableIconClickFocusProp',
+    prop: 'disableIconClickFocus',
     required: false,
-    description: 'Whether the input should focus when the icon is clicked.',
-    values: 'true, false',
-    default: 'true'
+    description: 'Whether to prevent the input from focusing when an icon is clicked.',
+    values: 'boolean',
+    default: 'false',
+    apiType: 'primitive'
   },
   {
     key: 'ariaLabelProp',
@@ -291,6 +293,15 @@ const styleSlotsInterface: PropData[] = [
     prop: 'leftIcon',
     required: false,
     description: 'Styles for the left icon slot.',
+    values: 'string[]',
+    default: '',
+    apiType: 'primitive'
+  },
+  {
+    key: 'rightIconsContainer',
+    prop: 'rightIconsContainer',
+    required: false,
+    description: 'Container for right icons, this includes clear, suffix, right-icon and chevrons from number input.',
     values: 'string[]',
     default: '',
     apiType: 'primitive'
@@ -469,6 +480,7 @@ const styles = {
         :clearable="form.clearable"
         @left-icon-click="useNotification({ text: 'Left Icon!!', color: 'surface' })"
         @right-icon-click="useNotification({ text: 'Right Icon!!', color: 'surface' })"
+        @suffix-icon-click="useNotification({ text: 'Suffix Icon!!', color: 'surface' })"
       >
         <template
           v-if="iconsInForm.left"
@@ -479,6 +491,12 @@ const styles = {
         <template
           v-if="iconsInForm.right"
           #right-icon
+        >
+          <vk-icon name="home" />
+        </template>
+        <template
+          v-if="iconsInForm.suffix"
+          #suffix-icon
         >
           <vk-icon name="home" />
         </template>
@@ -566,6 +584,10 @@ const styles = {
       <vk-checkbox
         v-model="iconsInForm.right"
         label="Right Icon"
+      />
+      <vk-checkbox
+        v-model="iconsInForm.suffix"
+        label="Suffix Icon"
       />
     </template>
 

--- a/packages/valko-ui-docs/app/pages/docs/(forms)/input.vue
+++ b/packages/valko-ui-docs/app/pages/docs/(forms)/input.vue
@@ -25,8 +25,7 @@ const form = ref<InputProps>({
 
 const iconsInForm = ref({
   left: false,
-  right: false,
-  suffix: false
+  right: false
 })
 
 const inputStates = reactive<Record<string, string>>({
@@ -180,15 +179,6 @@ const apiData: PropData[] = [
     apiType: 'custom-string'
   },
   {
-    key: 'disableIconClickFocusProp',
-    prop: 'disableIconClickFocus',
-    required: false,
-    description: 'Whether to prevent the input from focusing when an icon is clicked.',
-    values: 'boolean',
-    default: 'false',
-    apiType: 'primitive'
-  },
-  {
     key: 'ariaLabelProp',
     prop: 'ariaLabel',
     required: false,
@@ -304,15 +294,6 @@ const styleSlotsInterface: PropData[] = [
     prop: 'leftIcon',
     required: false,
     description: 'Styles for the left icon slot.',
-    values: 'string[]',
-    default: '',
-    apiType: 'primitive'
-  },
-  {
-    key: 'rightIconsContainer',
-    prop: 'rightIconsContainer',
-    required: false,
-    description: 'Container for right icons, this includes clear, suffix, right-icon and chevrons from number input.',
     values: 'string[]',
     default: '',
     apiType: 'primitive'
@@ -466,6 +447,8 @@ const styles = {
     ]
   }
 }
+
+const resetForceClearableInput = () => setTimeout(() => { inputStates.forceClearable = 'Try clearing me!' }, 1000)
 </script>
 
 <template>
@@ -490,10 +473,8 @@ const styles = {
         :step="form.step"
         :clearable="form.clearable"
         :force-clearable="form.forceClearable"
-        :disable-icon-click-focus="form.disableIconClickFocus"
         @left-icon-click="useNotification({ text: 'Left Icon!!', color: 'surface' })"
         @right-icon-click="useNotification({ text: 'Right Icon!!', color: 'surface' })"
-        @suffix-icon-click="useNotification({ text: 'Suffix Icon!!', color: 'surface' })"
       >
         <template
           v-if="iconsInForm.left"
@@ -504,12 +485,6 @@ const styles = {
         <template
           v-if="iconsInForm.right"
           #right-icon
-        >
-          <vk-icon name="home" />
-        </template>
-        <template
-          v-if="iconsInForm.suffix"
-          #suffix-icon
         >
           <vk-icon name="home" />
         </template>
@@ -601,10 +576,6 @@ const styles = {
       <vk-checkbox
         v-model="iconsInForm.right"
         label="Right Icon"
-      />
-      <vk-checkbox
-        v-model="iconsInForm.suffix"
-        label="Suffix Icon"
       />
     </template>
 
@@ -741,26 +712,11 @@ const styles = {
           force-clearable
           clearable
           label="Force Clearable"
-          @clear="resetForceClearable"
+          @clear="resetForceClearableInput"
         />
 
         <template #code>
           <code-block :code="generateSnippet<boolean>('forceClearable', { values: [true], extraProps: 'readonly clearable' })" />
-        </template>
-      </example-section>
-
-      <example-section title="Disable Icon Click Focus">
-        <vk-input
-          disable-icon-click-focus
-          label="Disable Icon Click Focus"
-        >
-          <template #left-icon>
-            <vk-icon name="home" />
-          </template>
-        </vk-input>
-
-        <template #code>
-          <code-block :code="generateSnippet<boolean>('disableIconClickFocus', { values: [true] })" />
         </template>
       </example-section>
 

--- a/packages/valko-ui-docs/app/pages/docs/(forms)/select.vue
+++ b/packages/valko-ui-docs/app/pages/docs/(forms)/select.vue
@@ -22,6 +22,11 @@ const form = ref<SelectProps>({
   clearable: false
 })
 
+const iconsInForm = ref({
+  left: false,
+  right: false
+})
+
 const exampleSectionModel = reactive<Record<string, number>>({ readonly: 1 })
 
 const apiData: PropData[] = [
@@ -337,7 +342,22 @@ const styles = {
         :size="form.size"
         :multiple="form.multiple"
         :clearable="form.clearable"
-      />
+        @left-icon-click="useNotification({ text: 'Left Icon!!', color: 'surface' })"
+        @right-icon-click="useNotification({ text: 'Right Icon!!', color: 'surface' })"
+      >
+        <template
+          v-if="iconsInForm.left"
+          #left-icon
+        >
+          <vk-icon name="home" />
+        </template>
+        <template
+          v-if="iconsInForm.right"
+          #right-icon
+        >
+          <vk-icon name="home" />
+        </template>
+      </vk-select>
     </template>
 
     <template #playground-options>
@@ -390,6 +410,14 @@ const styles = {
       <vk-checkbox
         v-model="form.clearable"
         label="Clearable"
+      />
+      <vk-checkbox
+        v-model="iconsInForm.left"
+        label="Left Icon"
+      />
+      <vk-checkbox
+        v-model="iconsInForm.right"
+        label="Right Icon"
       />
     </template>
 

--- a/packages/valko-ui-docs/app/pages/docs/(forms)/select.vue
+++ b/packages/valko-ui-docs/app/pages/docs/(forms)/select.vue
@@ -23,9 +23,7 @@ const form = ref<SelectProps>({
 })
 
 const iconsInForm = ref({
-  left: false,
-  right: false,
-  suffix: false
+  left: false
 })
 
 const exampleSectionModel = reactive<Record<string, number>>({ readonly: 1 })
@@ -63,15 +61,6 @@ const apiData: PropData[] = [
     prop: 'disabled',
     required: false,
     description: 'Whether the Select is disabled or not.',
-    values: 'boolean',
-    default: 'false',
-    apiType: 'primitive'
-  },
-  {
-    key: 'disableIconClickFocusProp',
-    prop: 'disableIconClickFocus',
-    required: false,
-    description: 'Whether the Select is rounded or not.',
     values: 'boolean',
     default: 'false',
     apiType: 'primitive'
@@ -128,24 +117,6 @@ const apiData: PropData[] = [
     description: 'A hint for the Select',
     values: 'string',
     default: '',
-    apiType: 'primitive'
-  },
-  {
-    key: 'iconLeftProp',
-    prop: 'iconLeft',
-    required: false,
-    description: 'A icon on the left side for the Select',
-    values: 'string',
-    default: '',
-    apiType: 'primitive'
-  },
-  {
-    key: 'iconRightProp',
-    prop: 'iconRight',
-    required: false,
-    description: 'A icon on the right side for the Select',
-    values: 'string',
-    default: 'chevron-down',
     apiType: 'primitive'
   },
   {
@@ -279,72 +250,53 @@ const styleSlotsInterface: PropData[] = [
   }
 ]
 
-const optionsInterface: TableItem[] = [
+const optionsInterface: PropData[] = [
   {
     key: 'valueOption',
     prop: 'value',
+    required: true,
     description: 'The value of the option, which will be used as the modelValue when the option is selected.',
     values: 'string | number',
-    default: ''
+    default: '',
+    apiType: 'primitive'
   },
   {
     key: 'labelOption',
     prop: 'label',
+    required: true,
     description: 'The label displayed for the option.',
     values: 'string',
-    default: ''
+    default: '',
+    apiType: 'primitive'
   }
 ]
 
-const slotData: TableItem[] = [
+const slotData: SlotData[] = [
   {
     key: 'leftIconSlot',
     name: 'left-icon',
     description: 'Slot for placing an icon on the left side of the input field. This slot is typically used to include an icon for visual enhancement or to indicate input type.',
-    example: '<template #left-icon>\n  <!-- Your icon component goes here -->\n</template>'
-  },
-  {
-    key: 'rightIconSlot',
-    name: 'right-icon',
-    description: 'Slot for placing an icon on the right side of the input field. This slot is typically used to include an icon for actions like clear input or show/hide password.',
-    example: '<template #right-icon>\n  <!-- Your icon component goes here -->\n</template>'
-  },
-  {
-    key: 'suffixIconSlot',
-    name: 'suffix-icon',
-    description: 'Slot for placing an icon after the right icon. Defaults to chevron icon, provides isOpen and toggleDropdown slot props for dynamic behavior.',
-    example: '<template #suffix-icon>\n  <!-- Your icon component goes here -->\n</template>'
+    example: '<template #left-icon>\n  <!-- Your icon component goes here -->\n</template>',
+    apiType: 'slot'
   }
 ]
 
-const emitData: TableItem[] = [
+const emitData: EmitData[] = [
   {
     key: 'updateModelValueEmit',
     event: 'update:modelValue',
     description: 'Emitted when the selected value(s) in the Select component change.',
     values: 'string | number | undefined | Array<string | number>',
-    type: '(value: string | number | undefined | Array<string | number>) => void'
+    type: '(value: string | number | undefined | Array<string | number>) => void',
+    apiType: 'event'
   },
   {
     key: 'leftIconClickEmit',
     event: 'leftIconClick',
     description: 'Emitted when the left icon of the input is clicked.',
     values: '',
-    type: '() => void'
-  },
-  {
-    key: 'rightIconClickEmit',
-    event: 'rightIconClick',
-    description: 'Emitted when the right icon of the input is clicked.',
-    values: '',
-    type: '() => void'
-  },
-  {
-    key: 'suffixIconClickEmit',
-    event: 'suffixIconClick',
-    description: 'Emitted when the suffix icon of the input is clicked.',
-    values: '',
-    type: '() => void'
+    type: '() => void',
+    apiType: 'event'
   }
 ]
 
@@ -402,33 +354,12 @@ const styles = {
         :multiple="form.multiple"
         :clearable="form.clearable"
         @left-icon-click="useNotification({ text: 'Left Icon!!', color: 'surface' })"
-        @right-icon-click="useNotification({ text: 'Right Icon!!', color: 'surface' })"
-        @suffix-icon-click="useNotification({ text: 'Suffix Icon!!', color: 'surface' })"
       >
         <template
           v-if="iconsInForm.left"
           #left-icon
         >
           <vk-icon name="home" />
-        </template>
-        <template
-          v-if="iconsInForm.right"
-          #right-icon
-        >
-          <vk-icon name="home" />
-        </template>
-        <template
-          v-if="iconsInForm.suffix"
-          #suffix-icon="{ toggleDropdown, isOpen }"
-        >
-          <vk-icon
-            name="brand-vue"
-            :class="[
-              'block transition-transform  duration-200 ease-in-out',
-              { 'rotate-180': isOpen }
-            ]"
-            @click="toggleDropdown(!isOpen)"
-          />
         </template>
       </vk-select>
     </template>
@@ -487,14 +418,6 @@ const styles = {
       <vk-checkbox
         v-model="iconsInForm.left"
         label="Left Icon"
-      />
-      <vk-checkbox
-        v-model="iconsInForm.right"
-        label="Right Icon"
-      />
-      <vk-checkbox
-        v-model="iconsInForm.suffix"
-        label="Suffix Icon"
       />
     </template>
 
@@ -645,17 +568,8 @@ const styles = {
           </template>
         </vk-select>
 
-        <vk-select
-          :options="people"
-          label="Right Icon"
-        >
-          <template #right-icon>
-            <vk-icon name="home" />
-          </template>
-        </vk-select>
-
         <template #code>
-          <code-block :code="`${scriptCode}\n<template>\n  <vk-select :options=&quot;people&quot;>\n    <template #left-icon>\n      <vk-icon name=&quot;home&quot; />\n    </template>\n  </vk-select>\n\n  <vk-select :options=&quot;people&quot;>\n    <template #right-icon>\n      <vk-icon name=&quot;home&quot; />\n    </template>\n  </vk-select>\n</template>`" />
+          <code-block :code="`${scriptCode}\n<template>\n  <vk-select :options=&quot;people&quot;>\n    <template #left-icon>\n      <vk-icon name=&quot;home&quot; />`" />
         </template>
       </example-section>
     </template>
@@ -666,7 +580,9 @@ const styles = {
         :tables="[
           { title: 'Props', data: apiData, headers: 'props' },
           { title: 'Emits', data: emitData, headers: 'emits' },
-          { title: 'Style Slots', data: styleSlotsInterface, headers: 'interface' }
+          { title: 'Style Slots', data: styleSlotsInterface, headers: 'interface' },
+          { title: 'Options', data: optionsInterface, headers: 'interface' },
+          { title: 'Slots', data: slotData, headers: 'slots' }
         ]"
       />
     </template>

--- a/packages/valko-ui-docs/app/pages/docs/(forms)/select.vue
+++ b/packages/valko-ui-docs/app/pages/docs/(forms)/select.vue
@@ -19,7 +19,8 @@ const form = ref<SelectProps>({
   disabled: false,
   readonly: false,
   multiple: false,
-  clearable: false
+  clearable: false,
+  disableIconClickFocus: true
 })
 
 const iconsInForm = ref({
@@ -401,8 +402,10 @@ const styles = {
         :size="form.size"
         :multiple="form.multiple"
         :clearable="form.clearable"
+        :disable-icon-click-focus="form.disableIconClickFocus"
         @left-icon-click="useNotification({ text: 'Left Icon!!', color: 'surface' })"
         @right-icon-click="useNotification({ text: 'Right Icon!!', color: 'surface' })"
+        @suffix-icon-click="useNotification({ text: 'Suffix Icon!!', color: 'surface' })"
       >
         <template
           v-if="iconsInForm.left"
@@ -418,9 +421,16 @@ const styles = {
         </template>
         <template
           v-if="iconsInForm.suffix"
-          #suffix-icon
+          #suffix-icon="{ toggleDropdown, isOpen }"
         >
-          <vk-icon name="brand-vue" />
+          <vk-icon
+            name="brand-vue"
+            :class="[
+              'block transition-transform  duration-200 ease-in-out',
+              { 'rotate-180': isOpen }
+            ]"
+            @click="toggleDropdown(!isOpen)"
+          />
         </template>
       </vk-select>
     </template>
@@ -475,6 +485,10 @@ const styles = {
       <vk-checkbox
         v-model="form.clearable"
         label="Clearable"
+      />
+      <vk-checkbox
+        v-model="form.disableIconClickFocus"
+        label="Disable Icon Click Focus"
       />
       <vk-checkbox
         v-model="iconsInForm.left"

--- a/packages/valko-ui-docs/app/pages/docs/(forms)/select.vue
+++ b/packages/valko-ui-docs/app/pages/docs/(forms)/select.vue
@@ -24,7 +24,8 @@ const form = ref<SelectProps>({
 
 const iconsInForm = ref({
   left: false,
-  right: false
+  right: false,
+  suffix: false
 })
 
 const exampleSectionModel = reactive<Record<string, number>>({ readonly: 1 })
@@ -67,8 +68,8 @@ const apiData: PropData[] = [
     apiType: 'primitive'
   },
   {
-    key: 'roundedProp',
-    prop: 'rounded',
+    key: 'disableIconClickFocusProp',
+    prop: 'disableIconClickFocus',
     required: false,
     description: 'Whether the Select is rounded or not.',
     values: 'boolean',
@@ -97,7 +98,7 @@ const apiData: PropData[] = [
     key: 'modelValueProp',
     prop: 'modelValue',
     required: false,
-    description: 'The v-model for the Select',
+    description: 'The v-model for the Select.',
     values: 'string, number, Array<string | number>',
     default: '',
     apiType: 'primitive'
@@ -115,7 +116,7 @@ const apiData: PropData[] = [
     key: 'labelProp',
     prop: 'label',
     required: false,
-    description: 'The label for the Select',
+    description: 'The label for the Select.',
     values: 'string',
     default: '',
     apiType: 'primitive'
@@ -151,7 +152,7 @@ const apiData: PropData[] = [
     key: 'shapeProp',
     prop: 'shape',
     required: false,
-    description: 'The shape of the Button.',
+    description: 'The shape of the Select.',
     values: 'rounded, square, soft',
     default: 'soft',
     apiType: 'custom-string'
@@ -307,6 +308,12 @@ const slotData: TableItem[] = [
     name: 'right-icon',
     description: 'Slot for placing an icon on the right side of the input field. This slot is typically used to include an icon for actions like clear input or show/hide password.',
     example: '<template #right-icon>\n  <!-- Your icon component goes here -->\n</template>'
+  },
+  {
+    key: 'suffixIconSlot',
+    name: 'suffix-icon',
+    description: 'Slot for placing an icon after the right icon. Defaults to chevron icon, provides isOpen and toggleDropdown slot props for dynamic behavior.',
+    example: '<template #suffix-icon>\n  <!-- Your icon component goes here -->\n</template>'
   }
 ]
 
@@ -329,6 +336,13 @@ const emitData: TableItem[] = [
     key: 'rightIconClickEmit',
     event: 'rightIconClick',
     description: 'Emitted when the right icon of the input is clicked.',
+    values: '',
+    type: '() => void'
+  },
+  {
+    key: 'suffixIconClickEmit',
+    event: 'suffixIconClick',
+    description: 'Emitted when the suffix icon of the input is clicked.',
     values: '',
     type: '() => void'
   }
@@ -402,6 +416,12 @@ const styles = {
         >
           <vk-icon name="home" />
         </template>
+        <template
+          v-if="iconsInForm.suffix"
+          #suffix-icon
+        >
+          <vk-icon name="brand-vue" />
+        </template>
       </vk-select>
     </template>
 
@@ -463,6 +483,10 @@ const styles = {
       <vk-checkbox
         v-model="iconsInForm.right"
         label="Right Icon"
+      />
+      <vk-checkbox
+        v-model="iconsInForm.suffix"
+        label="Suffix Icon"
       />
     </template>
 

--- a/packages/valko-ui-docs/app/pages/docs/(forms)/select.vue
+++ b/packages/valko-ui-docs/app/pages/docs/(forms)/select.vue
@@ -19,8 +19,7 @@ const form = ref<SelectProps>({
   disabled: false,
   readonly: false,
   multiple: false,
-  clearable: false,
-  disableIconClickFocus: true
+  clearable: false
 })
 
 const iconsInForm = ref({
@@ -402,7 +401,6 @@ const styles = {
         :size="form.size"
         :multiple="form.multiple"
         :clearable="form.clearable"
-        :disable-icon-click-focus="form.disableIconClickFocus"
         @left-icon-click="useNotification({ text: 'Left Icon!!', color: 'surface' })"
         @right-icon-click="useNotification({ text: 'Right Icon!!', color: 'surface' })"
         @suffix-icon-click="useNotification({ text: 'Suffix Icon!!', color: 'surface' })"
@@ -485,10 +483,6 @@ const styles = {
       <vk-checkbox
         v-model="form.clearable"
         label="Clearable"
-      />
-      <vk-checkbox
-        v-model="form.disableIconClickFocus"
-        label="Disable Icon Click Focus"
       />
       <vk-checkbox
         v-model="iconsInForm.left"
@@ -598,6 +592,70 @@ const styles = {
 
         <template #code>
           <code-block :code="`${scriptCode}\n${generateSnippet<boolean>('readonly', { values: [true], extraProps })}`" />
+        </template>
+      </example-section>
+
+      <example-section title="Multiple">
+        <vk-select
+          multiple
+          clearable
+          :options="people"
+          label="Multiple"
+        />
+
+        <template #code>
+          <code-block :code="`${scriptCode}\n${generateSnippet<boolean>('multiple', { values: [true], extraProps })}`" />
+        </template>
+      </example-section>
+
+      <example-section title="Clearable">
+        <vk-select
+          clearable
+          :options="people"
+          label="Clearable"
+        />
+
+        <template #code>
+          <code-block :code="`${scriptCode}\n${generateSnippet<boolean>('clearable', { values: [true], extraProps })}`" />
+        </template>
+      </example-section>
+
+      <example-section title="Helpertext">
+        <vk-select
+          :options="people"
+          label="With Helpertext"
+          helpertext="Pick a person from the list."
+        />
+
+        <template #code>
+          <code-block :code="`${scriptCode}\n${generateSnippet<string>('helpertext', { values: ['Pick a person from the list.'], extraProps })}`" />
+        </template>
+      </example-section>
+
+      <example-section
+        title="Icons"
+        :style-slots="styles.default"
+      >
+        <vk-select
+          :options="people"
+          label="Left Icon"
+        >
+          <template #left-icon>
+            <vk-icon name="home" />
+          </template>
+        </vk-select>
+
+        <vk-select
+          :options="people"
+          label="Right Icon"
+        >
+          <template #right-icon>
+            <vk-icon name="home" />
+          </template>
+        </vk-select>
+
+        <template #code>
+          <code-block :code="`${scriptCode}\n<template>\n  <vk-select :options=&quot;people&quot;>\n    <template #left-icon>\n      <vk-icon name=&quot;home&quot; />\n    </template>\n  </vk-select>\n\n  <vk-select :options=&quot;people&quot;>\n    <template #right-icon>\n      <vk-icon name=&quot;home&quot; />\n    </template>\n  </vk-select>\n</template>`" />
         </template>
       </example-section>
     </template>

--- a/packages/valko-ui-docs/app/pages/docs/(forms)/select.vue
+++ b/packages/valko-ui-docs/app/pages/docs/(forms)/select.vue
@@ -278,14 +278,59 @@ const styleSlotsInterface: PropData[] = [
   }
 ]
 
-const emitData: EmitData[] = [
+const optionsInterface: TableItem[] = [
+  {
+    key: 'valueOption',
+    prop: 'value',
+    description: 'The value of the option, which will be used as the modelValue when the option is selected.',
+    values: 'string | number',
+    default: ''
+  },
+  {
+    key: 'labelOption',
+    prop: 'label',
+    description: 'The label displayed for the option.',
+    values: 'string',
+    default: ''
+  }
+]
+
+const slotData: TableItem[] = [
+  {
+    key: 'leftIconSlot',
+    name: 'left-icon',
+    description: 'Slot for placing an icon on the left side of the input field. This slot is typically used to include an icon for visual enhancement or to indicate input type.',
+    example: '<template #left-icon>\n  <!-- Your icon component goes here -->\n</template>'
+  },
+  {
+    key: 'rightIconSlot',
+    name: 'right-icon',
+    description: 'Slot for placing an icon on the right side of the input field. This slot is typically used to include an icon for actions like clear input or show/hide password.',
+    example: '<template #right-icon>\n  <!-- Your icon component goes here -->\n</template>'
+  }
+]
+
+const emitData: TableItem[] = [
   {
     key: 'updateModelValueEmit',
     event: 'update:modelValue',
     description: 'Emitted when the selected value(s) in the Select component change.',
-    values: 'any',
-    type: '(value: any) => void',
-    apiType: 'primitive'
+    values: 'string | number | undefined | Array<string | number>',
+    type: '(value: string | number | undefined | Array<string | number>) => void'
+  },
+  {
+    key: 'leftIconClickEmit',
+    event: 'leftIconClick',
+    description: 'Emitted when the left icon of the input is clicked.',
+    values: '',
+    type: '() => void'
+  },
+  {
+    key: 'rightIconClickEmit',
+    event: 'rightIconClick',
+    description: 'Emitted when the right icon of the input is clicked.',
+    values: '',
+    type: '() => void'
   }
 ]
 

--- a/packages/valko-ui-docs/app/pages/docs/(forms)/select.vue
+++ b/packages/valko-ui-docs/app/pages/docs/(forms)/select.vue
@@ -69,7 +69,7 @@ const apiData: PropData[] = [
     key: 'multipleProp',
     prop: 'multiple',
     required: false,
-    description: 'Wheter the Select is enabled to choose multiple options',
+    description: 'Whether the Select is enabled to choose multiple options.',
     values: 'boolean',
     default: 'false',
     apiType: 'primitive'
@@ -78,7 +78,7 @@ const apiData: PropData[] = [
     key: 'optionsProp',
     prop: 'options',
     required: false,
-    description: 'An array of options for the Select',
+    description: 'An array of options for the Select.',
     values: 'SelectOption[]',
     default: '[]',
     apiType: 'custom-type'
@@ -96,7 +96,7 @@ const apiData: PropData[] = [
     key: 'readonlyProp',
     prop: 'readonly',
     required: false,
-    description: 'Wheter the Select is readonly or not',
+    description: 'Whether the Select is readonly or not.',
     values: 'boolean',
     default: 'false',
     apiType: 'primitive'
@@ -114,7 +114,7 @@ const apiData: PropData[] = [
     key: 'helpertextProp',
     prop: 'helpertext',
     required: false,
-    description: 'A hint for the Select',
+    description: 'A hint for the Select.',
     values: 'string',
     default: '',
     apiType: 'primitive'
@@ -132,7 +132,16 @@ const apiData: PropData[] = [
     key: 'clearableProp',
     prop: 'clearable',
     required: false,
-    description: 'Allows to leave the selection empty and displays an icon that clears the selection when clicked.',
+    description: 'Allows the selection to be empty and displays an icon to clear the current selection.',
+    values: 'boolean',
+    default: 'false',
+    apiType: 'primitive'
+  },
+  {
+    key: 'disableIconClickFocusProp',
+    prop: 'disableIconClickFocus',
+    required: false,
+    description: 'Prevents the input from receiving focus when an icon is clicked.',
     values: 'boolean',
     default: 'false',
     apiType: 'primitive'
@@ -183,7 +192,7 @@ const apiData: PropData[] = [
     apiType: 'primitive'
   },
   {
-    key: 'styleSlotsProps',
+    key: 'styleSlotsProp',
     prop: 'styleSlots',
     required: false,
     description: 'Custom styles for different parts of the Select component.',
@@ -275,7 +284,7 @@ const slotData: SlotData[] = [
   {
     key: 'leftIconSlot',
     name: 'left-icon',
-    description: 'Slot for placing an icon on the left side of the input field. This slot is typically used to include an icon for visual enhancement or to indicate input type.',
+    description: 'Slot for rendering an icon on the left side of the Select.',
     example: '<template #left-icon>\n  <!-- Your icon component goes here -->\n</template>',
     apiType: 'slot'
   }
@@ -293,7 +302,7 @@ const emitData: EmitData[] = [
   {
     key: 'leftIconClickEmit',
     event: 'leftIconClick',
-    description: 'Emitted when the left icon of the input is clicked.',
+    description: 'Emitted when the Select left icon is clicked.',
     values: '',
     type: '() => void',
     apiType: 'event'
@@ -569,7 +578,7 @@ const styles = {
         </vk-select>
 
         <template #code>
-          <code-block :code="`${scriptCode}\n<template>\n  <vk-select :options=&quot;people&quot;>\n    <template #left-icon>\n      <vk-icon name=&quot;home&quot; />`" />
+          <code-block :code="`${scriptCode}\n<template>\n  <vk-select :options=&quot;people&quot;>\n    <template #left-icon>\n      <vk-icon name=&quot;home&quot; />\n    </template>\n  </vk-select>\n</template>`" />
         </template>
       </example-section>
     </template>


### PR DESCRIPTION
## Summary

This PR addresses some missing functionality around icon handling in `Input` and `Select`, along with aligning the documentation with the current component API.

## What changed

- Added `disableIconClickFocus` support to `Input` and forwarded the prop through `Select`.
- Fixed `Input` guard clauses so icon clicks and clear actions emit the expected events.
- Restored `Select`'s `left-icon` slot forwarding and `leftIconClick` event.
- Added test coverage for the new icon focus behavior and Select icon interactions.
- Updated the docs pages to reflect the current API:
  - Added missing props/events/slots.
  - Fixed outdated descriptions and typos.
  - Removed stale API entries.
  - Added missing examples.

## Notes

Most of these changes are documentation/API consistency fixes and small behavior corrections discovered while reviewing the icon slot handling.