### PR TITLE
test(vui-191): expand test coverage for core components.

### DIFF
--- a/.changeset/clean-oranges-hug.md
+++ b/.changeset/clean-oranges-hug.md
@@ -15,5 +15,10 @@
 - **Datepicker:** Removed right-icon listener (cannot be triggered on readonly input).
 
 ### Tests:
-- Improved coverage for keyboard navigation, ARIA, composables, rendering, animations.
+
+- Significantly increased coverage for components and composables, including functions, methods, computed properties, refs, watchers, and returned values.
 - Added missing tests for Calendar child components (DayView, YearView, MonthView, Header).
+- Improved ARIA and accessibility test coverage.
+- Refactored test structure for clarity: accurate describe blocks, modularized tests, and efficient use of beforeEach/afterEach to reduce repetition.
+- Added tests for new features and previously untested behaviors.
+- Enhanced test modularity and reduced code repetition.

--- a/.changeset/clean-oranges-hug.md
+++ b/.changeset/clean-oranges-hug.md
@@ -1,0 +1,12 @@
+---
+"@valko-ui/components": patch
+---
+
+## Valko-UI Components:
+
+**Components:**
+- Added a guard clause in the `Select` component to prevent runtime errors during keyboard navigation and testing.
+
+**Tests:**
+- Enhanced and expanded test coverage for Button, Checkbox, Menu, Select, Tabs, Textarea, and Time components.
+- Coverage improvements include: keyboard navigation, ARIA attributes, composable interactions, rendering, and animations.

--- a/.changeset/clean-oranges-hug.md
+++ b/.changeset/clean-oranges-hug.md
@@ -10,6 +10,9 @@
 - **Calendar:** Removed unreachable guard logic and added `data-selection-type` for reliable view switching tests.
 - **Breadcrumbs:** Updated `tabindex` logic to use `crumb disabled state`, improving accessibility and removing unreachable code.
 - **Popover:** Added `data-open` attribute for more reliable test assertions.
+- **Dropdown:** Removed unreachable guard clause in onItemClick.
+- **Timepicker:** Fixed unmount logic to remove event listener instead of adding; removed right-icon listener (cannot be triggered on readonly input).
+- **Datepicker:** Removed right-icon listener (cannot be triggered on readonly input).
 
 ### Tests:
 - Improved coverage for keyboard navigation, ARIA, composables, rendering, animations.

--- a/.changeset/clean-oranges-hug.md
+++ b/.changeset/clean-oranges-hug.md
@@ -4,9 +4,13 @@
 
 ## Valko-UI Components:
 
-**Components:**
-- Added a guard clause in the `Select` component to prevent runtime errors during keyboard navigation and testing.
+### Components:
 
-**Tests:**
-- Enhanced and expanded test coverage for Button, Checkbox, Menu, Select, Tabs, Textarea, and Time components.
-- Coverage improvements include: keyboard navigation, ARIA attributes, composable interactions, rendering, and animations.
+- **Select:** Added a guard clause to prevent runtime errors during keyboard navigation and testing.
+- **Calendar:** Removed unreachable guard logic and added `data-selection-type` for reliable view switching tests.
+- **Breadcrumbs:** Updated `tabindex` logic to use `crumb disabled state`, improving accessibility and removing unreachable code.
+- **Popover:** Added `data-open` attribute for more reliable test assertions.
+
+### Tests:
+- Improved coverage for keyboard navigation, ARIA, composables, rendering, animations.
+- Added missing tests for Calendar child components (DayView, YearView, MonthView, Header).

--- a/.changeset/two-adults-fly.md
+++ b/.changeset/two-adults-fly.md
@@ -1,7 +1,0 @@
----
-"@valko-ui/components": patch
----
-
-## Valko-UI Components
-
-- Added missing dev dependencies for Istanbul to fix test failures.

--- a/.changeset/two-adults-fly.md
+++ b/.changeset/two-adults-fly.md
@@ -1,0 +1,7 @@
+---
+"@valko-ui/components": patch
+---
+
+## Valko-UI Components
+
+- Added missing dev dependencies for Istanbul to fix test failures.

--- a/package-lock.json
+++ b/package-lock.json
@@ -2242,18 +2242,17 @@
       }
     },
     "node_modules/@nuxt/cli": {
-      "version": "3.33.1",
-      "resolved": "https://registry.npmjs.org/@nuxt/cli/-/cli-3.33.1.tgz",
-      "integrity": "sha512-/sCrcI0WemING9zASaXPgPDY7PrQTPlRyCXlSgGx8VwRAkWbxGaPhIc3kZQikgLwVAwy+muWVV4Wks8OTtW5Tw==",
+      "version": "3.34.0",
+      "resolved": "https://registry.npmjs.org/@nuxt/cli/-/cli-3.34.0.tgz",
+      "integrity": "sha512-KVI4xSo96UtUUbmxr9ouWTytbj1LzTw5alsM4vC/gSY/l8kPMRAlq0XpNSAVTDJyALzLY70WhaIMX24LJLpdFw==",
       "license": "MIT",
       "dependencies": {
-        "@bomb.sh/tab": "^0.0.12",
-        "@clack/prompts": "^1.0.0",
+        "@bomb.sh/tab": "^0.0.14",
+        "@clack/prompts": "^1.1.0",
         "c12": "^3.3.3",
-        "citty": "^0.2.0",
+        "citty": "^0.2.1",
         "confbox": "^0.2.4",
         "consola": "^3.4.2",
-        "copy-paste": "^2.2.0",
         "debug": "^4.4.3",
         "defu": "^6.1.4",
         "exsolve": "^1.0.8",
@@ -2270,11 +2269,12 @@
         "pkg-types": "^2.3.0",
         "scule": "^1.3.0",
         "semver": "^7.7.4",
-        "srvx": "^0.11.2",
+        "srvx": "^0.11.9",
         "std-env": "^3.10.0",
+        "tinyclip": "^0.1.12",
         "tinyexec": "^1.0.2",
         "ufo": "^1.6.3",
-        "youch": "^4.1.0-beta.13"
+        "youch": "^4.1.0"
       },
       "bin": {
         "nuxi": "bin/nuxi.mjs",
@@ -2283,10 +2283,10 @@
         "nuxt-cli": "bin/nuxi.mjs"
       },
       "engines": {
-        "node": "^16.10.0 || >=18.0.0"
+        "node": "^16.14.0 || >=18.0.0"
       },
       "peerDependencies": {
-        "@nuxt/schema": "^4.3.0"
+        "@nuxt/schema": "^4.3.1"
       },
       "peerDependenciesMeta": {
         "@nuxt/schema": {
@@ -2295,16 +2295,16 @@
       }
     },
     "node_modules/@nuxt/cli/node_modules/@bomb.sh/tab": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/@bomb.sh/tab/-/tab-0.0.12.tgz",
-      "integrity": "sha512-dYRwg4MqfHR5/BcTy285XOGRhjQFmNpaJBZ0tl2oU+RY595MQ5ApTF6j3OvauPAooHL6cfoOZMySQrOQztT8RQ==",
+      "version": "0.0.14",
+      "resolved": "https://registry.npmjs.org/@bomb.sh/tab/-/tab-0.0.14.tgz",
+      "integrity": "sha512-cHMk2LI430MVoX1unTt9oK1iZzQS4CYDz97MSxKLNErW69T43Z2QLFTpdS/3jVOIKrIADWfuxQ+nQNJkNV7E4w==",
       "license": "MIT",
       "bin": {
-        "tab": "dist/bin/cli.js"
+        "tab": "dist/bin/cli.mjs"
       },
       "peerDependencies": {
         "cac": "^6.7.14",
-        "citty": "^0.1.6",
+        "citty": "^0.1.6 || ^0.2.0",
         "commander": "^13.1.0"
       },
       "peerDependenciesMeta": {
@@ -4518,9 +4518,9 @@
       "license": "MIT"
     },
     "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.8.tgz",
-      "integrity": "sha512-wzJwL82/arVfeSP3BLr1oTy40XddjtEdrdgtJ4lLRBu06mP3q/8HGM6K0JRlQuTA3XB0pNJx2so/nmpY4xyOew==",
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.9.tgz",
+      "integrity": "sha512-w6oiRWgEBl04QkFZgmW+jnU1EC9b57Oihi2ot3HNWIQRqgHp5PnYDia5iZ5FF7rpa4EQdiqMDXjlqKGXBhsoXw==",
       "license": "MIT"
     },
     "node_modules/@rollup/plugin-alias": {
@@ -8122,26 +8122,6 @@
       "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-2.0.0.tgz",
       "integrity": "sha512-RAj4E421UYRgqokKUmotqAwuplYw15qtdXfY+hGzgCJ/MBjCVZcSoHK/kH9kocfjRjcDME7IiDWR/1WX1TM2Pg==",
       "license": "MIT"
-    },
-    "node_modules/copy-paste": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/copy-paste/-/copy-paste-2.2.0.tgz",
-      "integrity": "sha512-jqSL4r9DSeiIvJZStLzY/sMLt9ToTM7RsK237lYOTG+KcbQJHGala3R1TUpa8h1p9adswVgIdV4qGbseVhL4lg==",
-      "dependencies": {
-        "iconv-lite": "^0.4.8"
-      }
-    },
-    "node_modules/copy-paste/node_modules/iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/core-js-compat": {
       "version": "3.48.0",
@@ -14474,6 +14454,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/sax": {
@@ -15402,6 +15383,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tinyclip": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/tinyclip/-/tinyclip-0.1.12.tgz",
+      "integrity": "sha512-Ae3OVUqifDw0wBriIBS7yVaW44Dp6eSHQcyq4Igc7eN2TJH/2YsicswaW+J/OuMvhpDPOKEgpAZCjkb4hpoyeA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^16.14.0 || >= 17.3.0"
+      }
+    },
     "node_modules/tinyexec": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
@@ -15607,27 +15597,27 @@
       "license": "0BSD"
     },
     "node_modules/turbo": {
-      "version": "2.8.15",
-      "resolved": "https://registry.npmjs.org/turbo/-/turbo-2.8.15.tgz",
-      "integrity": "sha512-ERZf7pKOR155NKs/PZt1+83NrSEJfUL7+p9/TGZg/8xzDVMntXEFQlX4CsNJQTyu4h3j+dZYiQWOOlv5pssuHQ==",
+      "version": "2.8.16",
+      "resolved": "https://registry.npmjs.org/turbo/-/turbo-2.8.16.tgz",
+      "integrity": "sha512-u6e9e3cTTpE2adQ1DYm3A3r8y3LAONEx1jYvJx6eIgSY4bMLxIxs0riWzI0Z/IK903ikiUzRPZ2c1Ph5lVLkhA==",
       "dev": true,
       "license": "MIT",
       "bin": {
         "turbo": "bin/turbo"
       },
       "optionalDependencies": {
-        "turbo-darwin-64": "2.8.15",
-        "turbo-darwin-arm64": "2.8.15",
-        "turbo-linux-64": "2.8.15",
-        "turbo-linux-arm64": "2.8.15",
-        "turbo-windows-64": "2.8.15",
-        "turbo-windows-arm64": "2.8.15"
+        "turbo-darwin-64": "2.8.16",
+        "turbo-darwin-arm64": "2.8.16",
+        "turbo-linux-64": "2.8.16",
+        "turbo-linux-arm64": "2.8.16",
+        "turbo-windows-64": "2.8.16",
+        "turbo-windows-arm64": "2.8.16"
       }
     },
     "node_modules/turbo-darwin-64": {
-      "version": "2.8.15",
-      "resolved": "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-2.8.15.tgz",
-      "integrity": "sha512-EElCh+Ltxex9lXYrouV3hHjKP3HFP31G91KMghpNHR/V99CkFudRcHcnWaorPbzAZizH1m8o2JkLL8rptgb8WQ==",
+      "version": "2.8.16",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-2.8.16.tgz",
+      "integrity": "sha512-KWa4hUMWrpADC6Q/wIHRkBLw6X6MV9nx6X7hSXbTrrMz0KdaKhmfudUZ3sS76bJFmgArBU25cSc0AUyyrswYxg==",
       "cpu": [
         "x64"
       ],
@@ -15639,9 +15629,9 @@
       ]
     },
     "node_modules/turbo-darwin-arm64": {
-      "version": "2.8.15",
-      "resolved": "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-2.8.15.tgz",
-      "integrity": "sha512-ORmvtqHiHwvNynSWvLIleyU8dKtwQ4ILk39VsEwfKSEzSHWYWYxZhBmD9GAGRPlNl7l7S1irrziBlDEGVpq+vQ==",
+      "version": "2.8.16",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-2.8.16.tgz",
+      "integrity": "sha512-NBgaqBDLQSZlJR4D5XCkQq6noaO0RvIgwm5eYFJYL3bH5dNu8o0UBpq7C5DYnQI8+ybyoHFjT5/icN4LeUYLow==",
       "cpu": [
         "arm64"
       ],
@@ -15653,9 +15643,9 @@
       ]
     },
     "node_modules/turbo-linux-64": {
-      "version": "2.8.15",
-      "resolved": "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-2.8.15.tgz",
-      "integrity": "sha512-Bk1E61a+PCWUTfhqfXFlhEJMLp6nak0J0Qt14IZX1og1zyaiBLkM6M1GQFbPpiWfbUcdLwRaYQhO0ySB07AJ8w==",
+      "version": "2.8.16",
+      "resolved": "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-2.8.16.tgz",
+      "integrity": "sha512-VYPdcCRevI9kR/hr1H1xwXy7QQt/jNKiim1e1mjANBXD2E9VZWMkIL74J1Huad5MbU3/jw7voHOqDPLJPC2p6w==",
       "cpu": [
         "x64"
       ],
@@ -15667,9 +15657,9 @@
       ]
     },
     "node_modules/turbo-linux-arm64": {
-      "version": "2.8.15",
-      "resolved": "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-2.8.15.tgz",
-      "integrity": "sha512-3BX0Vk+XkP0uiZc8pkjQGNsAWjk5ojC53bQEMp6iuhSdWpEScEFmcT6p7DL7bcJmhP2mZ1HlAu0A48wrTGCtvg==",
+      "version": "2.8.16",
+      "resolved": "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-2.8.16.tgz",
+      "integrity": "sha512-beq8tgUVI3uwkQkXJMiOr/hfxQRw54M3elpBwqgYFfemiK5LhCjjcwO0DkE8GZZfElBIlk+saMAQOZy3885wNQ==",
       "cpu": [
         "arm64"
       ],
@@ -15681,9 +15671,9 @@
       ]
     },
     "node_modules/turbo-windows-64": {
-      "version": "2.8.15",
-      "resolved": "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-2.8.15.tgz",
-      "integrity": "sha512-m14ogunMF+grHZ1jzxSCO6q0gEfF1tmr+0LU+j1QNd/M1X33tfKnQqmpkeUR/REsGjfUlkQlh6PAzqlT3cA3Pg==",
+      "version": "2.8.16",
+      "resolved": "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-2.8.16.tgz",
+      "integrity": "sha512-Ig7b46iUgiOIkea/D3Z7H+zNzvzSnIJcLYFpZLA0RxbUTrbLhv9qIPwv3pT9p/abmu0LXVKHxaOo+p26SuDhzw==",
       "cpu": [
         "x64"
       ],
@@ -15695,9 +15685,9 @@
       ]
     },
     "node_modules/turbo-windows-arm64": {
-      "version": "2.8.15",
-      "resolved": "https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-2.8.15.tgz",
-      "integrity": "sha512-HWh6dnzhl7nu5gRwXeqP61xbyDBNmQ4UCeWNa+si4/6RAtHlKEcZTNs7jf4U+oqBnbtv4uxbKZZPf/kN0EK4+A==",
+      "version": "2.8.16",
+      "resolved": "https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-2.8.16.tgz",
+      "integrity": "sha512-fOWjbEA2PiE2HEnFQrwNZKYEdjewyPc2no9GmrXklZnTCuMsxeCN39aVlKpKpim03Zq/ykIuvApGwq8ZbfS2Yw==",
       "cpu": [
         "arm64"
       ],
@@ -18101,7 +18091,6 @@
         "toastify-js": "^1.12.0"
       },
       "devDependencies": {
-        "@istanbuljs/schema": "^0.1.3",
         "@nuxt/kit": "^3.16.2",
         "@tailwindcss/postcss": "^4.1.3",
         "@types/node": "^20.10.7",
@@ -18111,11 +18100,6 @@
         "@vitest/coverage-istanbul": "^3.1.1",
         "@vue/test-utils": "^2.4.6",
         "clean-css": "^5.3.2",
-        "istanbul-lib-coverage": "^3.2.2",
-        "istanbul-lib-instrument": "^6.0.3",
-        "istanbul-lib-report": "^3.0.1",
-        "istanbul-lib-source-maps": "^5.0.6",
-        "istanbul-reports": "^3.2.0",
         "jsdom": "^23.2.0",
         "path": "^0.12.7",
         "postcss": "^8.4.24",
@@ -18123,7 +18107,6 @@
         "rollup-plugin-typescript2": "^0.36.0",
         "tailwind-variants": "^3.1.1",
         "tailwindcss": "^4.1.3",
-        "test-exclude": "^7.0.1",
         "typescript": "^5.8.3",
         "vite": "^6.2.5",
         "vite-plugin-dts": "^4.5.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18101,6 +18101,7 @@
         "toastify-js": "^1.12.0"
       },
       "devDependencies": {
+        "@istanbuljs/schema": "^0.1.3",
         "@nuxt/kit": "^3.16.2",
         "@tailwindcss/postcss": "^4.1.3",
         "@types/node": "^20.10.7",
@@ -18110,6 +18111,11 @@
         "@vitest/coverage-istanbul": "^3.1.1",
         "@vue/test-utils": "^2.4.6",
         "clean-css": "^5.3.2",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-instrument": "^6.0.3",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.2.0",
         "jsdom": "^23.2.0",
         "path": "^0.12.7",
         "postcss": "^8.4.24",
@@ -18117,6 +18123,7 @@
         "rollup-plugin-typescript2": "^0.36.0",
         "tailwind-variants": "^3.1.1",
         "tailwindcss": "^4.1.3",
+        "test-exclude": "^7.0.1",
         "typescript": "^5.8.3",
         "vite": "^6.2.5",
         "vite-plugin-dts": "^4.5.3",

--- a/packages/valko-ui-components/package.json
+++ b/packages/valko-ui-components/package.json
@@ -29,7 +29,6 @@
     "vue": "^3.5.8"
   },
   "devDependencies": {
-    "@istanbuljs/schema": "^0.1.3",
     "@nuxt/kit": "^3.16.2",
     "@tailwindcss/postcss": "^4.1.3",
     "@types/node": "^20.10.7",
@@ -39,11 +38,6 @@
     "@vitest/coverage-istanbul": "^3.1.1",
     "@vue/test-utils": "^2.4.6",
     "clean-css": "^5.3.2",
-    "istanbul-lib-coverage": "^3.2.2",
-    "istanbul-lib-instrument": "^6.0.3",
-    "istanbul-lib-report": "^3.0.1",
-    "istanbul-lib-source-maps": "^5.0.6",
-    "istanbul-reports": "^3.2.0",
     "jsdom": "^23.2.0",
     "path": "^0.12.7",
     "postcss": "^8.4.24",
@@ -51,7 +45,6 @@
     "rollup-plugin-typescript2": "^0.36.0",
     "tailwind-variants": "^3.1.1",
     "tailwindcss": "^4.1.3",
-    "test-exclude": "^7.0.1",
     "typescript": "^5.8.3",
     "vite": "^6.2.5",
     "vite-plugin-dts": "^4.5.3",

--- a/packages/valko-ui-components/package.json
+++ b/packages/valko-ui-components/package.json
@@ -29,6 +29,7 @@
     "vue": "^3.5.8"
   },
   "devDependencies": {
+    "@istanbuljs/schema": "^0.1.3",
     "@nuxt/kit": "^3.16.2",
     "@tailwindcss/postcss": "^4.1.3",
     "@types/node": "^20.10.7",
@@ -38,6 +39,11 @@
     "@vitest/coverage-istanbul": "^3.1.1",
     "@vue/test-utils": "^2.4.6",
     "clean-css": "^5.3.2",
+    "istanbul-lib-coverage": "^3.2.2",
+    "istanbul-lib-instrument": "^6.0.3",
+    "istanbul-lib-report": "^3.0.1",
+    "istanbul-lib-source-maps": "^5.0.6",
+    "istanbul-reports": "^3.2.0",
     "jsdom": "^23.2.0",
     "path": "^0.12.7",
     "postcss": "^8.4.24",
@@ -45,6 +51,7 @@
     "rollup-plugin-typescript2": "^0.36.0",
     "tailwind-variants": "^3.1.1",
     "tailwindcss": "^4.1.3",
+    "test-exclude": "^7.0.1",
     "typescript": "^5.8.3",
     "vite": "^6.2.5",
     "vite-plugin-dts": "^4.5.3",

--- a/packages/valko-ui-components/src/__test__/Avatar.spec.ts
+++ b/packages/valko-ui-components/src/__test__/Avatar.spec.ts
@@ -290,4 +290,28 @@ describe('Avatar component', () => {
       })
     })
   })
+
+  describe('Aria attributes', () => {
+    it('should have aria-label attribute when ariaLabel prop is provided', () => {
+      wrapper = mount(VkAvatar, {
+        props: {
+          src: 'example.url',
+          ariaLabel: 'User Avatar'
+        }
+      })
+
+      expect(wrapper.find('.vk-avatar').attributes('aria-label')).toBe('User Avatar')
+    })
+  })
+
+  it('should default to prop name if ariaLabel prop is not provided', () => {
+    wrapper = mount(VkAvatar, {
+      props: {
+        src: 'example.url',
+        name: 'Brandon Coper'
+      }
+    })
+
+    expect(wrapper.find('.vk-avatar').attributes('aria-label')).toBe('Brandon Coper')
+  })
 })

--- a/packages/valko-ui-components/src/__test__/Breadcrumbs.spec.ts
+++ b/packages/valko-ui-components/src/__test__/Breadcrumbs.spec.ts
@@ -318,7 +318,9 @@ describe('Breadcrumbs component', () => {
     it('should have left icon if given', () => {
       const wrapper = mount(VkBreadcrumbs, {
         props: {
-          crumbs
+          crumbs: [
+            { key: 'home', title: 'Home', leftIcon: 'home' }
+          ]
         }
       })
 
@@ -328,11 +330,69 @@ describe('Breadcrumbs component', () => {
     it('should have right icon if given', () => {
       const wrapper = mount(VkBreadcrumbs, {
         props: {
-          crumbs
+          crumbs: [
+            { key: 'music', title: 'Music', rightIcon: 'music' }
+          ]
         }
       })
 
       expect(wrapper.find('i.ti.ti-music').exists()).toBe(true)
+    })
+
+    it('should not have left icon if not given', () => {
+      const wrapper = mount(VkBreadcrumbs, {
+        props: {
+          crumbs: [
+            { key: 'artist', title: 'Artist' }
+          ]
+        }
+      })
+
+      expect(wrapper.findAll('.vk-breadcrumbs__a').at(2)?.find('i.ti.ti-home').exists()).toBeUndefined()
+    })
+
+    it('should not have right icon if not given', () => {
+      const wrapper = mount(VkBreadcrumbs, {
+        props: {
+          crumbs: [
+            { key: 'artist', title: 'Artist' }
+          ]
+        }
+      })
+
+      expect(wrapper.findAll('.vk-breadcrumbs__a').at(2)?.find('i.ti.ti-music').exists()).toBeUndefined()
+    })
+  })
+
+  describe('Accessibility', () => {
+    it('should have tabindex 0 if crumb is not the last one', () => {
+      const wrapper = mount(VkBreadcrumbs, {
+        props: {
+          crumbs
+        }
+      })
+
+      expect(wrapper.findAll('.vk-breadcrumbs__a').at(0)?.attributes('tabindex')).toBe('0')
+    })
+
+    it('should have tabindex -1 if crumb is disabled', () => {
+      const wrapper = mount(VkBreadcrumbs, {
+        props: {
+          crumbs
+        }
+      })
+
+      expect(wrapper.findAll('.vk-breadcrumbs__a').at(1)?.attributes('tabindex')).toBe('-1')
+    })
+
+    it('should have tabindex 0 if crumb is not disabled', () => {
+      const wrapper = mount(VkBreadcrumbs, {
+        props: {
+          crumbs
+        }
+      })
+
+      expect(wrapper.findAll('.vk-breadcrumbs__a').at(2)?.attributes('tabindex')).toBe('0')
     })
   })
 

--- a/packages/valko-ui-components/src/__test__/Breadcrumbs.spec.ts
+++ b/packages/valko-ui-components/src/__test__/Breadcrumbs.spec.ts
@@ -360,7 +360,7 @@ describe('Breadcrumbs component', () => {
         }
       })
 
-      expect(wrapper.findAll('.vk-breadcrumbs__a').at(2)?.find('i.ti.ti-music').exists()).toBeUndefined()
+      expect(wrapper.find('i.ti.ti-music').exists()).toBe(false)
     })
   })
 

--- a/packages/valko-ui-components/src/__test__/Breadcrumbs.spec.ts
+++ b/packages/valko-ui-components/src/__test__/Breadcrumbs.spec.ts
@@ -348,7 +348,7 @@ describe('Breadcrumbs component', () => {
         }
       })
 
-      expect(wrapper.findAll('.vk-breadcrumbs__a').at(2)?.find('i.ti.ti-home').exists()).toBeUndefined()
+      expect(wrapper.find('i.ti.ti-home').exists()).toBe(false)
     })
 
     it('should not have right icon if not given', () => {

--- a/packages/valko-ui-components/src/__test__/Button.spec.ts
+++ b/packages/valko-ui-components/src/__test__/Button.spec.ts
@@ -450,6 +450,40 @@ describe('Button component', () => {
     })
   })
 
+  describe('Ripple', () => {
+    it('should create ripple effect on mouse down', async () => {
+      wrapper = mount(VkButton, {})
+      const buttonElement = wrapper.find('.vk-button__base')
+      await buttonElement.trigger('mousedown')
+
+      expect(buttonElement.find('.vk-ripple__container').exists()).toBe(true)
+    })
+
+    it('should not create ripple effect when disabled is true', async () => {
+      wrapper = mount(VkButton, {
+        props: {
+          disabled: true
+        }
+      })
+      const buttonElement = wrapper.find('.vk-button__base')
+      await buttonElement.trigger('mousedown')
+
+      expect(buttonElement.find('.vk-ripple__container').exists()).toBe(false)
+    })
+
+    it('should not create ripple effect when loading is true', async () => {
+      wrapper = mount(VkButton, {
+        props: {
+          loading: true
+        }
+      })
+      const buttonElement = wrapper.find('.vk-button__base')
+      await buttonElement.trigger('mousedown')
+
+      expect(buttonElement.find('.vk-ripple__container').exists()).toBe(false)
+    })
+  })
+
   describe('With slots', () => {
     it('should be empty', () => {
       const wrapper = mount(VkButton, {})

--- a/packages/valko-ui-components/src/__test__/Calendar.spec.ts
+++ b/packages/valko-ui-components/src/__test__/Calendar.spec.ts
@@ -35,9 +35,9 @@ const { useDateAdapter } = vi.hoisted(() => ({
         1900249200000,
         2215004400000
       ]),
-      onSelectDay: () => 1728961200000,
-      onSelectMonth: () => 1727751600000,
-      onSelectYear: () => 1704078000000,
+      onSelectDay: vi.fn(() => 1728961200000),
+      onSelectMonth: vi.fn(() => 1727751600000),
+      onSelectYear: vi.fn(() => 1704078000000),
       getWeekdays: () => ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
       getMonths: () => ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
     }
@@ -324,8 +324,24 @@ describe('Calendar component', () => {
     })
   })
 
-  describe('Available views & changing beetwen them', () => {
-    describe('Available views inferred by format', () => {
+  describe('Adapter & Methods', () => {
+    describe('Watcher: format prop', () => {
+      it('should update view when format prop changes', async () => {
+        const wrapper = mount(VkCalendar, {
+          props: {
+            modelValue,
+            adapter,
+            format: 'YYYY-MM-DD'
+          }
+        })
+
+        await wrapper.setProps({ format: 'YYYY' })
+
+        expect(wrapper.find('.vk-calendar__view-container').attributes()).toHaveProperty('data-current-view', 'years')
+      })
+    })
+
+    describe('onSelectYear', () => {
       it('should only be in year view if format only contains Y', async () => {
         const wrapper = mount(VkCalendar, {
           props: {
@@ -333,18 +349,45 @@ describe('Calendar component', () => {
             adapter,
             format: 'YYYY'
           }
-
         })
 
-        const periodButton = wrapper.find('.vk-calendar__period-button')
-        const gridButton = wrapper.findAll('.vk-calendar__grid-button')[0]
-        await gridButton.trigger('click')
+        await wrapper.findAll('.vk-calendar__grid-button').at(0)?.trigger('click')
 
-        expect(periodButton.text()).toBe('2010 - 2029')
+        expect(wrapper.find('.vk-calendar__period-button').text()).toBe('2010 - 2029')
+      })
+
+      it('should show month view after selecting a year if selectionType is not year-only', async () => {
+        const wrapper = mount(VkCalendar, {
+          props: {
+            modelValue,
+            adapter,
+            format: 'YYYY-MM'
+          }
+        })
+
+        await wrapper.find('.vk-calendar__period-button').trigger('click')
+        await wrapper.findAll('.vk-calendar__grid-button').at(0)?.trigger('click')
+
+        expect(wrapper.find('.vk-calendar__view-container').attributes()).toHaveProperty('data-current-view', 'months')
+      })
+
+      it('should show month view after selecting a year if selectionType is not year-only', async () => {
+        const wrapper = mount(VkCalendar, {
+          props: {
+            modelValue,
+            adapter,
+            format: 'YYYY-MM'
+          }
+        })
+
+        await wrapper.find('.vk-calendar__period-button').trigger('click')
+        await wrapper.findAll('.vk-calendar__grid-button')[0].trigger('click')
+
+        expect(wrapper.find('.vk-calendar__view-container').attributes()).toHaveProperty('data-current-view', 'months')
       })
     })
 
-    describe('Cycling between views', () => {
+    describe('onSelectMonth', () => {
       it('should only cycle between month & year view if format not contains D', async () => {
         const wrapper = mount(VkCalendar, {
           props: {
@@ -352,16 +395,45 @@ describe('Calendar component', () => {
             adapter,
             format: 'YYYY-MM'
           }
-
         })
 
-        const periodButton = wrapper.find('.vk-calendar__period-button')
-        const gridButton = wrapper.findAll('.vk-calendar__grid-button')[0]
-        await gridButton.trigger('click')
+        await wrapper.findAll('.vk-calendar__grid-button').at(0)?.trigger('click')
 
-        expect(periodButton.text()).toBe('2024')
+        expect(wrapper.find('.vk-calendar__period-button').text()).toBe('2024')
       })
 
+      it('should show day view after selecting a month if selectionType is not month-only or month-year', async () => {
+        const wrapper = mount(VkCalendar, {
+          props: {
+            modelValue,
+            adapter,
+            format: 'YYYY-MM-DD'
+          }
+        })
+
+        await wrapper.find('.vk-calendar__period-button').trigger('click')
+        await wrapper.findAll('.vk-calendar__grid-button').at(0)?.trigger('click')
+
+        expect(wrapper.find('.vk-calendar__view-container').attributes()).toHaveProperty('data-current-view', 'days')
+      })
+
+      it('should show day view after selecting a month if selectionType is not month-only or month-year', async () => {
+        const wrapper = mount(VkCalendar, {
+          props: {
+            modelValue,
+            adapter,
+            format: 'YYYY-MM-DD'
+          }
+        })
+
+        await wrapper.find('.vk-calendar__period-button').trigger('click')
+        await wrapper.findAll('.vk-calendar__grid-button')[0].trigger('click')
+
+        expect(wrapper.find('.vk-calendar__view-container').attributes()).toHaveProperty('data-current-view', 'days')
+      })
+    })
+
+    describe('View logic', () => {
       it('should switch to month view when period button is clicked in day view', async () => {
         const wrapper = mount(VkCalendar, {
           props: {
@@ -370,12 +442,103 @@ describe('Calendar component', () => {
           }
         })
 
-        const periodButton = wrapper.find('.vk-calendar__period-button')
-        await periodButton.trigger('click')
+        await wrapper.find('.vk-calendar__period-button').trigger('click')
 
-        const gridButtons = wrapper.findAll('.vk-calendar__grid-button')[0]
-        expect(gridButtons.text()).toBe('Jan')
+        expect(wrapper.find('.vk-calendar__view-container').attributes()).toHaveProperty('data-current-view', 'months')
+      })
 
+      it('should render the day view if format does not include D, M, or Y', () => {
+        const wrapper = mount(VkCalendar, {
+          props: {
+            modelValue,
+            adapter,
+            format: ''
+          }
+        })
+
+        expect(wrapper.find('.vk-calendar__view-container').attributes()).toHaveProperty('data-current-view', 'days')
+      })
+
+      it('should return day-month if format contains D and M but not Y', async () => {
+        const wrapper = mount(VkCalendar, {
+          props: {
+            modelValue,
+            adapter,
+            format: 'DD-MM'
+          }
+        })
+
+        await wrapper.find('.vk-calendar__period-button').trigger('click')
+
+        expect(wrapper.attributes()).toHaveProperty('data-selection-type', 'day-month')
+      })
+    })
+
+    describe('onChangeMonth', () => {
+      it('should go to previous year and last month when clicking left arrow in January', async () => {
+        const customAdapter = {
+          ...adapter,
+          formattedDates: computed(() => ({
+            ...adapter.formattedDates.value,
+            display: {
+              ...adapter.formattedDates.value.display,
+              month: 0,
+              year: 2024
+            }
+          }))
+        }
+
+        const wrapper = mount(VkCalendar, {
+          props: {
+            modelValue,
+            adapter: customAdapter,
+            format: 'YYYY-MM-DD'
+          }
+        })
+
+        await wrapper.findAll('.vk-calendar__arrows').at(0)?.trigger('click')
+
+        expect(customAdapter.onSelectMonth).toHaveBeenCalledWith(11)
+      })
+
+      it('should go to next year and first month when clicking right arrow in December', async () => {
+        const customAdapter = {
+          ...adapter,
+          formattedDates: computed(() => ({
+            ...adapter.formattedDates.value,
+            display: {
+              ...adapter.formattedDates.value.display,
+              month: 11,
+              year: 2024
+            }
+          }))
+        }
+
+        const wrapper = mount(VkCalendar, {
+          props: {
+            modelValue,
+            adapter: customAdapter,
+            format: 'YYYY-MM-DD'
+          }
+        })
+
+        await wrapper.findAll('.vk-calendar__arrows').at(1)?.trigger('click')
+
+        expect(customAdapter.onSelectMonth).toHaveBeenCalledWith(0)
+      })
+
+      it('should go to the selected month when clicking right arrow in a non-edge month', async () => {
+        const wrapper = mount(VkCalendar, {
+          props: {
+            modelValue,
+            adapter,
+            format: 'YYYY-MM-DD'
+          }
+        })
+
+        await wrapper.findAll('.vk-calendar__arrows').at(1)?.trigger('click')
+
+        expect(adapter.onSelectMonth).toHaveBeenCalledWith(10)
       })
     })
   })

--- a/packages/valko-ui-components/src/__test__/Calendar.spec.ts
+++ b/packages/valko-ui-components/src/__test__/Calendar.spec.ts
@@ -1,5 +1,5 @@
 import { ref, computed, toValue } from 'vue'
-import { VueWrapper, mount } from '@vue/test-utils'
+import { VueWrapper, mount, shallowMount } from '@vue/test-utils'
 import VkCalendar from '#valkoui/components/Calendar.vue'
 import type { AdapterResult } from '#valkoui/types/Calendar'
 
@@ -322,6 +322,44 @@ describe('Calendar component', () => {
         expect(wrapper.find('.vk-calendar__ghost').exists()).toBe(true)
       })
     })
+
+    describe('When format prop changes', () => {
+      it('should render the correct view when format prop is YYYY', () => {
+        wrapper = shallowMount(VkCalendar, {
+          props: {
+            modelValue,
+            adapter,
+            format: 'YYYY'
+          }
+        })
+
+        expect(wrapper.find('vk-calendar-year-view-stub').exists()).toBe(true)
+      })
+
+      it('should render the correct view when format prop is MM', () => {
+        wrapper = shallowMount(VkCalendar, {
+          props: {
+            modelValue,
+            adapter,
+            format: 'MM'
+          }
+        })
+
+        expect(wrapper.find('vk-calendar-month-view-stub').exists()).toBe(true)
+      })
+
+      it('should render the correct view when format prop is DD', () => {
+        wrapper = shallowMount(VkCalendar, {
+          props: {
+            modelValue,
+            adapter,
+            format: 'DD'
+          }
+        })
+
+        expect(wrapper.find('vk-calendar-day-view-stub').exists()).toBe(true)
+      })
+    })
   })
 
   describe('Adapter & Methods', () => {
@@ -342,7 +380,7 @@ describe('Calendar component', () => {
     })
 
     describe('onSelectYear', () => {
-      it('should only be in year view if format only contains Y', async () => {
+      it('should directly emit the value if the format is year-only', async () => {
         const wrapper = mount(VkCalendar, {
           props: {
             modelValue,

--- a/packages/valko-ui-components/src/__test__/Calendar.spec.ts
+++ b/packages/valko-ui-components/src/__test__/Calendar.spec.ts
@@ -370,21 +370,6 @@ describe('Calendar component', () => {
 
         expect(wrapper.find('.vk-calendar__view-container').attributes()).toHaveProperty('data-current-view', 'months')
       })
-
-      it('should show month view after selecting a year if selectionType is not year-only', async () => {
-        const wrapper = mount(VkCalendar, {
-          props: {
-            modelValue,
-            adapter,
-            format: 'YYYY-MM'
-          }
-        })
-
-        await wrapper.find('.vk-calendar__period-button').trigger('click')
-        await wrapper.findAll('.vk-calendar__grid-button')[0].trigger('click')
-
-        expect(wrapper.find('.vk-calendar__view-container').attributes()).toHaveProperty('data-current-view', 'months')
-      })
     })
 
     describe('onSelectMonth', () => {
@@ -413,21 +398,6 @@ describe('Calendar component', () => {
 
         await wrapper.find('.vk-calendar__period-button').trigger('click')
         await wrapper.findAll('.vk-calendar__grid-button').at(0)?.trigger('click')
-
-        expect(wrapper.find('.vk-calendar__view-container').attributes()).toHaveProperty('data-current-view', 'days')
-      })
-
-      it('should show day view after selecting a month if selectionType is not month-only or month-year', async () => {
-        const wrapper = mount(VkCalendar, {
-          props: {
-            modelValue,
-            adapter,
-            format: 'YYYY-MM-DD'
-          }
-        })
-
-        await wrapper.find('.vk-calendar__period-button').trigger('click')
-        await wrapper.findAll('.vk-calendar__grid-button')[0].trigger('click')
 
         expect(wrapper.find('.vk-calendar__view-container').attributes()).toHaveProperty('data-current-view', 'days')
       })

--- a/packages/valko-ui-components/src/__test__/CalendarDayView.spec.ts
+++ b/packages/valko-ui-components/src/__test__/CalendarDayView.spec.ts
@@ -1,0 +1,236 @@
+import VkCalendarDayView from '#valkoui/components/CalendarDayView.vue'
+import { ref, computed, toValue } from 'vue'
+import { VueWrapper, mount } from '@vue/test-utils'
+import type { AdapterResult } from '#valkoui/types/Calendar'
+
+const { useDateAdapter } = vi.hoisted(() => ({
+  useDateAdapter: vi.fn(() => ([
+    ref(1729017518),
+    computed(() => '2024-10-15'),
+    {
+      formattedDates: computed(() => ({
+        selected: {
+          day: 15,
+          month: 9,
+          year: 2024,
+          lastDayOfMonth: 31,
+          firstWeekDay: 2,
+          obj: new Date(2024, 10, 15)
+        },
+        display: {
+          day: 15,
+          month: 9,
+          year: 2024,
+          lastDayOfMonth: 31,
+          firstWeekDay: 2,
+          obj: new Date(2024, 10, 15)
+        }
+      })),
+      disabledDates: computed(() => [
+        1705320000000,
+        1710936000000,
+        1717545600000,
+        1723420800000,
+        1736953200000,
+        1900249200000,
+        2215004400000
+      ]),
+      onSelectDay: vi.fn(() => 1728961200000),
+      onSelectMonth: vi.fn(() => 1727751600000),
+      onSelectYear: vi.fn(() => 1704078000000),
+      getWeekdays: () => ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
+      getMonths: () => ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
+    }
+  ] as AdapterResult))
+}))
+
+vi.mock('#valkoui/composables/useDateAdapter.ts', () => ({
+  default: useDateAdapter
+}))
+
+const [ model, , adapter ] = useDateAdapter()
+const modelValue = toValue(model)
+
+const baseProps = {
+  modelValue,
+  adapter,
+  selectionType: 'day',
+  format: 'DD-MM-YYYY',
+  daysInMonth: adapter.formattedDates.value.display.lastDayOfMonth,
+  startsOn: adapter.formattedDates.value.display.firstWeekDay,
+  selected: adapter.formattedDates.value.selected,
+  display: adapter.formattedDates.value.display,
+  weekDays: adapter.getWeekdays(),
+  monthNames: adapter.getMonths()
+}
+
+describe('CalendarDayView Component', () => {
+  describe('Rendering', () => {
+    let wrapper: VueWrapper
+
+    beforeEach(() => {
+      wrapper = mount(VkCalendarDayView, {
+        props: {
+          ...baseProps
+        }
+      })
+    })
+
+    it('should render the component', () => {
+      expect(wrapper.exists()).toBe(true)
+    })
+  })
+
+  describe('Methods and computeds', () => {
+    let wrapper: VueWrapper
+
+    beforeEach(() => {
+      wrapper = mount(VkCalendarDayView, {
+        props: {
+          ...baseProps
+        }
+      })
+    })
+
+    describe('gridCells', () => {
+      it.each([28, 29, 30, 31])('renders %i day cells for a month with %i days', (days) => {
+        const wrapper = mount(VkCalendarDayView, {
+          props: {
+            ...baseProps,
+            daysInMonth: days,
+            startsOn: 0
+          }
+        })
+
+        const dayButtons = wrapper.findAll('.vk-calendar__grid-button').filter(btn => !isNaN(Number(btn.text())))
+
+        expect(dayButtons.length).toBe(days)
+      })
+    })
+
+    describe('isSelected', () => {
+      it('should grid button render with correct variant if selected', () => {
+        const selectedDayButton = wrapper.findAll('.vk-calendar__grid-button').find(btn => btn.text() === '15')
+        const isSelected = selectedDayButton?.classes().includes('bg-primary')
+
+        expect(isSelected).toBe(true)
+      })
+
+      it('should grid button render with correct variant if not selected', () => {
+        const selectedDayButton = wrapper.findAll('.vk-calendar__grid-button').find(btn => btn.text() === '10')
+        const isSelected = selectedDayButton?.classes().includes('bg-primary')
+
+        expect(isSelected).toBe(false)
+      })
+
+      it('should grid button render with correct variant if not selected', () => {
+        const unselectedDayButton = wrapper.findAll('.vk-calendar__grid-button').find(btn => btn.text() === '10')
+        const isSelected = unselectedDayButton?.classes().includes('text-on-surface')
+
+        expect(isSelected).toBe(true)
+      })
+    })
+
+    describe('isArrowDisabled', () => {
+      it('should disable previous month arrow if min date is reached', () => {
+        const wrapper = mount(VkCalendarDayView, {
+          props: {
+            ...baseProps,
+            min: {
+              day: 1,
+              month: 9,
+              year: 2024,
+              lastDayOfMonth: 31,
+              firstWeekDay: 2,
+              obj: new Date(2024, 10, 1)
+            }
+          }
+        })
+
+        const isDisabled = wrapper.findAll('.vk-calendar__arrows').at(0)?.attributes('aria-disabled') === 'true'
+
+        expect(isDisabled).toBe(true)
+      })
+
+      it('should disable next month arrow if max date is reached', () => {
+        const wrapper = mount(VkCalendarDayView, {
+          props: {
+            ...baseProps,
+            max: {
+              day: 30,
+              month: 9,
+              year: 2024,
+              lastDayOfMonth: 31,
+              firstWeekDay: 2,
+              obj: new Date(2024, 10, 30)
+            }
+          }
+        })
+
+        const isDisabled = wrapper.findAll('.vk-calendar__arrows').at(1)?.attributes('aria-disabled') === 'true'
+
+        expect(isDisabled).toBe(true)
+      })
+    })
+
+    describe('isWeekend and disable weekends', () => {
+      it('should disable weekend days if disableWeekends is true', () => {
+        const wrapper = mount(VkCalendarDayView, {
+          props: {
+            ...baseProps,
+            disableWeekends: true
+          }
+        })
+
+        const weekendDayButtons = wrapper.findAll('.vk-calendar__grid-button').filter(btn => {
+          const day = Number(btn.text())
+          const date = new Date(2024, 9, day)
+          const dayOfWeek = date.getDay()
+          return dayOfWeek === 0 || dayOfWeek === 6
+        })
+
+        weekendDayButtons.forEach(btn => {
+          expect(btn.attributes('aria-disabled')).toBe('true')
+        })
+      })
+    })
+
+    describe('onArrowClick', () => {
+      it('should emit changeMonth with correct value when previous arrow is clicked', async () => {
+        await wrapper.findAll('.vk-calendar__arrows').at(0)?.trigger('click')
+
+        expect(wrapper.emitted('changeMonth')?.at(0)).toEqual([8])
+      })
+
+      it('should emit changeMonth with correct value when next arrow is clicked', async () => {
+        await wrapper.findAll('.vk-calendar__arrows').at(1)?.trigger('click')
+
+        expect(wrapper.emitted('changeMonth')?.at(0)).toEqual([10])
+      })
+    })
+  })
+
+  describe('Emits', () => {
+    let wrapper: VueWrapper
+
+    beforeEach(() => {
+      wrapper = mount(VkCalendarDayView, {
+        props: {
+          ...baseProps
+        }
+      })
+    })
+
+    it('should emit selectDay when a day is selected', async () => {
+      await wrapper.findAll('.vk-calendar__grid-button').at(14)?.trigger('click')
+
+      expect(wrapper.emitted()).toHaveProperty('selectDay')
+    })
+
+    it('should emit viewChange when period button is clicked', async () => {
+      await wrapper.find('.vk-calendar__period-button').trigger('click')
+
+      expect(wrapper.emitted()).toHaveProperty('viewChange')
+    })
+  })
+})

--- a/packages/valko-ui-components/src/__test__/CalendarHeader.spec.ts
+++ b/packages/valko-ui-components/src/__test__/CalendarHeader.spec.ts
@@ -1,0 +1,114 @@
+import VkCalendarHeader from '#valkoui/components/CalendarHeader.vue'
+import { ref, computed, toValue } from 'vue'
+import { VueWrapper, mount } from '@vue/test-utils'
+import type { AdapterResult } from '#valkoui/types/Calendar'
+
+const { useDateAdapter } = vi.hoisted(() => ({
+  useDateAdapter: vi.fn(() => ([
+    ref(1729017518),
+    computed(() => '2024-10-15'),
+    {
+      formattedDates: computed(() => ({
+        selected: {
+          day: 15,
+          month: 9,
+          year: 2024,
+          lastDayOfMonth: 31,
+          firstWeekDay: 2,
+          obj: new Date(2024, 10, 15)
+        },
+        display: {
+          day: 15,
+          month: 9,
+          year: 2024,
+          lastDayOfMonth: 31,
+          firstWeekDay: 2,
+          obj: new Date(2024, 10, 15)
+        }
+      })),
+      disabledDates: computed(() => [
+        1705320000000,
+        1710936000000,
+        1717545600000,
+        1723420800000,
+        1736953200000,
+        1900249200000,
+        2215004400000
+      ]),
+      onSelectDay: vi.fn(() => 1728961200000),
+      onSelectMonth: vi.fn(() => 1727751600000),
+      onSelectYear: vi.fn(() => 1704078000000),
+      getWeekdays: () => ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
+      getMonths: () => ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
+    }
+  ] as AdapterResult))
+}))
+
+vi.mock('#valkoui/composables/useDateAdapter.ts', () => ({
+  default: useDateAdapter
+}))
+
+const [ model, , adapter ] = useDateAdapter()
+const modelValue = toValue(model)
+
+const baseProps = {
+  modelValue,
+  adapter,
+  format: 'DD-MM-YYYY'
+}
+
+describe('CalendarHeader Component', () => {
+  let wrapper: VueWrapper
+
+  beforeEach(() => {
+    wrapper = mount(VkCalendarHeader, {
+      props: {
+        ...baseProps
+      }
+    })
+  })
+
+  describe('Rendering', () => {
+    it('should render properly', () => {
+      expect(wrapper.exists()).toBe(true)
+    })
+
+    it('should display the given loaded period', async () => {
+      await wrapper.setProps({ loadedPeriod: '10-2024' })
+
+      expect(wrapper.find('.vk-calendar__period-button').text()).toBe('10-2024')
+    })
+
+    it('should disable left arrow when disabledLeft is true', async () => {
+      await wrapper.setProps({ disabledLeft: true })
+
+      expect(wrapper.findAll('.vk-calendar__arrows').at(0)?.attributes('aria-disabled')).toBe('true')
+    })
+
+    it('should disable right arrow when disabledRight is true', async () => {
+      await wrapper.setProps({ disabledRight: true })
+
+      expect(wrapper.findAll('.vk-calendar__arrows').at(1)?.attributes('aria-disabled')).toBe('true')
+    })
+  })
+
+  describe('Emits', () => {
+    it('should emit previousClick when left arrow is clicked', async () => {
+      await wrapper.findAll('.vk-calendar__arrows').at(0)?.trigger('click')
+
+      expect(wrapper.emitted('previousClick')).toBeTruthy()
+    })
+
+    it('should emit nextClick when right arrow is clicked', async () => {
+      await wrapper.findAll('.vk-calendar__arrows').at(1)?.trigger('click')
+
+      expect(wrapper.emitted('nextClick')).toBeTruthy()
+    })
+
+    it('should emit viewChange when period label is clicked', async () => {
+      await wrapper.find('.vk-calendar__period-button').trigger('click')
+
+      expect(wrapper.emitted()).toHaveProperty('viewChange')
+    })
+  })
+})

--- a/packages/valko-ui-components/src/__test__/CalendarMonthView.spec.ts
+++ b/packages/valko-ui-components/src/__test__/CalendarMonthView.spec.ts
@@ -39,7 +39,7 @@ const { useDateAdapter } = vi.hoisted(() => ({
       onSelectMonth: vi.fn(() => 1727751600000),
       onSelectYear: vi.fn(() => 1704078000000),
       getWeekdays: () => ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
-      getMonths: () => ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
+      getMonths: () => ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
     }
   ] as AdapterResult))
 }))
@@ -78,7 +78,7 @@ describe('CalendarMonthView Component', () => {
 
     it('should render month buttons', () => {
       const monthButtons = wrapper.findAll('.vk-calendar__grid-button')
-      expect(monthButtons.length).toBe(11)
+      expect(monthButtons.length).toBe(12)
     })
 
     describe('disabled months', () => {

--- a/packages/valko-ui-components/src/__test__/CalendarMonthView.spec.ts
+++ b/packages/valko-ui-components/src/__test__/CalendarMonthView.spec.ts
@@ -1,0 +1,148 @@
+import VkCalendarMonthView from '#valkoui/components/CalendarMonthView.vue'
+import { ref, computed, toValue } from 'vue'
+import { VueWrapper, mount } from '@vue/test-utils'
+import type { AdapterResult } from '#valkoui/types/Calendar'
+
+const { useDateAdapter } = vi.hoisted(() => ({
+  useDateAdapter: vi.fn(() => ([
+    ref(1729017518),
+    computed(() => '2024-10-15'),
+    {
+      formattedDates: computed(() => ({
+        selected: {
+          day: 15,
+          month: 9,
+          year: 2024,
+          lastDayOfMonth: 31,
+          firstWeekDay: 2,
+          obj: new Date(2024, 10, 15)
+        },
+        display: {
+          day: 15,
+          month: 9,
+          year: 2024,
+          lastDayOfMonth: 31,
+          firstWeekDay: 2,
+          obj: new Date(2024, 10, 15)
+        }
+      })),
+      disabledDates: computed(() => [
+        1705320000000,
+        1710936000000,
+        1717545600000,
+        1723420800000,
+        1736953200000,
+        1900249200000,
+        2215004400000
+      ]),
+      onSelectDay: vi.fn(() => 1728961200000),
+      onSelectMonth: vi.fn(() => 1727751600000),
+      onSelectYear: vi.fn(() => 1704078000000),
+      getWeekdays: () => ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
+      getMonths: () => ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
+    }
+  ] as AdapterResult))
+}))
+
+vi.mock('#valkoui/composables/useDateAdapter.ts', () => ({
+  default: useDateAdapter
+}))
+
+const [ model, , adapter ] = useDateAdapter()
+const modelValue = toValue(model)
+
+const baseProps = {
+  modelValue,
+  adapter,
+  format: 'DD-MM-YYYY',
+  selected: adapter.formattedDates.value.selected,
+  display: adapter.formattedDates.value.display,
+  monthNames: adapter.getMonths()
+}
+
+describe('CalendarMonthView Component', () => {
+  let wrapper: VueWrapper
+
+  beforeEach(() => {
+    wrapper = mount(VkCalendarMonthView, {
+      props: {
+        ...baseProps
+      }
+    })
+  })
+
+  describe('Rendering', () => {
+    it('should render the component', () => {
+      expect(wrapper.exists()).toBe(true)
+    })
+
+    it('should render month buttons', () => {
+      const monthButtons = wrapper.findAll('.vk-calendar__grid-button')
+      expect(monthButtons.length).toBe(11)
+    })
+
+    describe('disabled months', () => {
+      it('should disable months before min month', async () => {
+        await wrapper.setProps({
+          min: {
+            day: 1,
+            month: 4,
+            year: 2024,
+            lastDayOfMonth: 30,
+            firstWeekDay: 1,
+            obj: new Date(2024, 4, 1)
+          }
+        })
+
+        const monthButtons = wrapper.findAll('.vk-calendar__grid-button')
+        monthButtons.slice(0, 4).forEach((button) => {
+          expect(button.attributes('aria-disabled') === 'true').toBe(true)
+        })
+      })
+
+      it('should disable months after max month', async () => {
+        await wrapper.setProps({
+          max: {
+            day: 1,
+            month: 7,
+            year: 2024,
+            lastDayOfMonth: 31,
+            firstWeekDay: 1,
+            obj: new Date(2024, 7, 1)
+          }
+        })
+
+        const monthButtons = wrapper.findAll('.vk-calendar__grid-button')
+        monthButtons.slice(8).forEach((button) => {
+          expect(button.attributes('aria-disabled') === 'true').toBe(true)
+        })
+      })
+    })
+  })
+
+  describe('Emits', () => {
+    it('should emit selectMonth with correct value when a month is clicked', async () => {
+      await wrapper.findAll('.vk-calendar__grid-button').at(4)?.trigger('click')
+
+      expect(wrapper.emitted('selectMonth')?.at(0)).toEqual([4])
+    })
+
+    it('should emit viewChange when period button is clicked', async () => {
+      await wrapper.find('.vk-calendar__period-button').trigger('click')
+
+      expect(wrapper.emitted('viewChange')?.at(0)).toEqual(['years'])
+    })
+
+    it('should emit changeYear when previous arrow is clicked', async () => {
+      await wrapper.findAll('.vk-calendar__arrows').at(0)?.trigger('click')
+
+      expect(wrapper.emitted('changeYear')?.at(0)).toEqual([2023])
+    })
+
+    it('should emit changeYear when next arrow is clicked', async () => {
+      await wrapper.findAll('.vk-calendar__arrows').at(1)?.trigger('click')
+
+      expect(wrapper.emitted('changeYear')?.at(0)).toEqual([2025])
+    })
+  })
+})

--- a/packages/valko-ui-components/src/__test__/CalendarYearView.spec.ts
+++ b/packages/valko-ui-components/src/__test__/CalendarYearView.spec.ts
@@ -1,0 +1,160 @@
+import VkCalendarYearView from '#valkoui/components/CalendarYearView.vue'
+import { ref, computed, toValue } from 'vue'
+import { VueWrapper, mount } from '@vue/test-utils'
+import type { AdapterResult } from '#valkoui/types/Calendar'
+
+const { useDateAdapter } = vi.hoisted(() => ({
+  useDateAdapter: vi.fn(() => ([
+    ref(1729017518),
+    computed(() => '2024-10-15'),
+    {
+      formattedDates: computed(() => ({
+        selected: {
+          day: 15,
+          month: 9,
+          year: 2024,
+          lastDayOfMonth: 31,
+          firstWeekDay: 2,
+          obj: new Date(2024, 10, 15)
+        },
+        display: {
+          day: 15,
+          month: 9,
+          year: 2024,
+          lastDayOfMonth: 31,
+          firstWeekDay: 2,
+          obj: new Date(2024, 10, 15)
+        }
+      })),
+      disabledDates: computed(() => [
+        1705320000000,
+        1710936000000,
+        1717545600000,
+        1723420800000,
+        1736953200000,
+        1900249200000,
+        2215004400000
+      ]),
+      onSelectDay: vi.fn(() => 1728961200000),
+      onSelectMonth: vi.fn(() => 1727751600000),
+      onSelectYear: vi.fn(() => 1704078000000),
+      getWeekdays: () => ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
+      getMonths: () => ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
+    }
+  ] as AdapterResult))
+}))
+
+vi.mock('#valkoui/composables/useDateAdapter.ts', () => ({
+  default: useDateAdapter
+}))
+
+const [ model, , adapter ] = useDateAdapter()
+const modelValue = toValue(model)
+
+const baseProps = {
+  modelValue,
+  adapter,
+  format: 'DD-MM-YYYY',
+  startsOn: adapter.formattedDates.value.display.year,
+  selected: adapter.formattedDates.value.selected
+}
+
+describe('CalendarYearView Component', () => {
+  let wrapper: VueWrapper
+
+  beforeEach(() => {
+    wrapper = mount(VkCalendarYearView, {
+      props: {
+        ...baseProps
+      }
+    })
+  })
+
+  describe('Rendering', () => {
+    it('should render the component', () => {
+      expect(wrapper.exists()).toBe(true)
+    })
+
+    describe('Years Grid', () => {
+      it('should render 12 year buttons', () => {
+        const yearButtons = wrapper.findAll('.vk-calendar__grid-button')
+
+        expect(yearButtons.length).toBe(20)
+      })
+    })
+
+    describe('disabled years', () => {
+      it('should disable years before min year', async () => {
+        await wrapper.setProps({
+          minYear: 2015
+        })
+
+        const yearButtons = wrapper.findAll('.vk-calendar__grid-button')
+
+        yearButtons.slice(0, 5).forEach((button) => {
+          expect(button.attributes('aria-disabled')).toBe('true')
+        })
+
+        yearButtons.slice(5).forEach((button) => {
+          expect(button.attributes('aria-disabled')).toBe('false')
+        })
+      })
+
+      it('should disable years after max year', async () => {
+        await wrapper.setProps({
+          maxYear: 2025
+        })
+
+        const yearButtons = wrapper.findAll('.vk-calendar__grid-button')
+
+        yearButtons.slice(0, 16).forEach((button) => {
+          expect(button.attributes('aria-disabled')).toBe('false')
+        })
+
+        yearButtons.slice(16).forEach((button) => {
+          expect(button.attributes('aria-disabled')).toBe('true')
+        })
+      })
+    })
+
+    describe('yearList', () => {
+      it('should generate a list of years centered around the display year', () => {
+        const yearButtons = wrapper.findAll('.vk-calendar__grid-button')
+        const expectedYears = [
+          '2010', '2011', '2012', '2013', '2014',
+          '2015', '2016', '2017', '2018', '2019',
+          '2020', '2021', '2022', '2023', '2024',
+          '2025', '2026', '2027', '2028', '2029'
+        ]
+
+        yearButtons.forEach((button, index) => {
+          expect(button.text()).toBe(expectedYears[index])
+        })
+      })
+    })
+  })
+
+  describe('Functionality', () => {
+    describe('Arrow Buttons', () => {
+      it('should correctly jump back 20 years when previous arrow is clicked', async () => {
+        await wrapper.findAll('.vk-calendar__arrows').at(0)?.trigger('click')
+
+        expect(wrapper.find('.vk-calendar__period-button').text()).toBe('1990 - 2009')
+      })
+
+      it('should correctly jump forward 20 years when next arrow is clicked', async () => {
+        await wrapper.findAll('.vk-calendar__arrows').at(1)?.trigger('click')
+
+        expect(wrapper.find('.vk-calendar__period-button').text()).toBe('2030 - 2049')
+      })
+    })
+  })
+
+  describe('Emits', () => {
+    it('should emit selectYear when a year is clicked', async () => {
+      await wrapper.findAll('.vk-calendar__grid-button').at(0)?.trigger('click')
+
+      expect(wrapper.emitted('selectYear')?.at(0)).toEqual([2010])
+    })
+  })
+})

--- a/packages/valko-ui-components/src/__test__/CalendarYearView.spec.ts
+++ b/packages/valko-ui-components/src/__test__/CalendarYearView.spec.ts
@@ -76,7 +76,7 @@ describe('CalendarYearView Component', () => {
     })
 
     describe('Years Grid', () => {
-      it('should render 12 year buttons', () => {
+      it('should render 20 year buttons', () => {
         const yearButtons = wrapper.findAll('.vk-calendar__grid-button')
 
         expect(yearButtons.length).toBe(20)

--- a/packages/valko-ui-components/src/__test__/Card.spec.ts
+++ b/packages/valko-ui-components/src/__test__/Card.spec.ts
@@ -183,5 +183,28 @@ describe('Card component', () => {
       wrapper.find('.vk-card').trigger('click')
       expect(wrapper.emitted()).toHaveProperty('click')
     })
+
+    it('should not emit click event when isPressable is false', () => {
+      const wrapper = mount(VkCard, {
+        props: {
+          isPressable: false
+        }
+      })
+
+      wrapper.find('.vk-card').trigger('click')
+      expect(wrapper.emitted()).not.toHaveProperty('click')
+    })
+
+    it('should not emit click when disabled is true', () => {
+      const wrapper = mount(VkCard, {
+        props: {
+          isPressable: true,
+          disabled: true
+        }
+      })
+
+      wrapper.find('.vk-card').trigger('click')
+      expect(wrapper.emitted()).not.toHaveProperty('click')
+    })
   })
 })

--- a/packages/valko-ui-components/src/__test__/Checkbox.spec.ts
+++ b/packages/valko-ui-components/src/__test__/Checkbox.spec.ts
@@ -247,6 +247,61 @@ describe('Checkbox component', () => {
     })
   })
 
+  describe('Arias', () => {
+    it('should set aria-describedby when helpertext is present', () => {
+      wrapper = mount(VkCheckbox, {
+        props: {
+          helpertext: 'Help text'
+        }
+      })
+      const helpertextId = wrapper.find('.vk-checkbox__helpertext').attributes('id')
+      const describedby = wrapper.find('.vk-checkbox__container').attributes('aria-describedby')
+
+      expect(describedby).toContain(helpertextId)
+    })
+
+    it('should set aria-describedby when aria-describedby prop is present', () => {
+      wrapper = mount(VkCheckbox, {
+        props: {
+          ariaDescribedBy: 'external-id'
+        }
+      })
+
+      expect(wrapper.find('.vk-checkbox__container').attributes('aria-describedby')).toContain('external-id')
+    })
+
+    it('should set aria-describedby with both helpertext id and aria-describedby prop', () => {
+      wrapper = mount(VkCheckbox, {
+        props: {
+          helpertext: 'Help text',
+          ariaDescribedBy: 'external-id'
+        }
+      })
+      const helpertextId = wrapper.find('.vk-checkbox__helpertext').attributes('id')
+      const describedby = wrapper.find('.vk-checkbox__container').attributes('aria-describedby')
+
+      expect(describedby).toContain(`${helpertextId} external-id`)
+    })
+  })
+
+  describe('Tabindex', () => {
+    it('should set tabindex to -1 when disabled', () => {
+      wrapper = mount(VkCheckbox, {
+        props: { disabled: true }
+      })
+
+      expect(wrapper.find('.vk-checkbox__container').attributes('tabindex')).toBe('-1')
+    })
+
+    it('should set tabindex to 0 when not disabled', () => {
+      wrapper = mount(VkCheckbox, {
+        props: { disabled: false }
+      })
+
+      expect(wrapper.find('.vk-checkbox__container').attributes('tabindex')).toBe('0')
+    })
+  })
+
   describe('Emits', () => {
     it('should emit update event', () => {
       const wrapper = mount(VkCheckbox, {})

--- a/packages/valko-ui-components/src/__test__/Checkbox.spec.ts
+++ b/packages/valko-ui-components/src/__test__/Checkbox.spec.ts
@@ -309,5 +309,23 @@ describe('Checkbox component', () => {
       wrapper.find('.vk-checkbox__container').trigger('click')
       expect(wrapper.emitted('update:modelValue'))
     })
+
+    it('should not emit update event when disabled', () => {
+      const wrapper = mount(VkCheckbox, {
+        props: { disabled: true }
+      })
+
+      wrapper.find('.vk-checkbox__container').trigger('click')
+      expect(wrapper.emitted('update:modelValue')).toBeUndefined()
+    })
+
+    it('should not emit update event when readonly', () => {
+      const wrapper = mount(VkCheckbox, {
+        props: { readonly: true }
+      })
+
+      wrapper.find('.vk-checkbox__container').trigger('click')
+      expect(wrapper.emitted('update:modelValue')).toBeUndefined()
+    })
   })
 })

--- a/packages/valko-ui-components/src/__test__/Collapse.spec.ts
+++ b/packages/valko-ui-components/src/__test__/Collapse.spec.ts
@@ -1,3 +1,4 @@
+import { inject } from 'vue'
 import { VueWrapper, mount } from '@vue/test-utils'
 import VkCollapse from '#valkoui/components/Collapse.vue'
 import VkCollapseItem from '#valkoui/components/CollapseItem.vue'
@@ -151,6 +152,54 @@ describe('Collapse component', () => {
       await collapseItems[0].trigger('click')
       await collapseItems[1].trigger('click')
       expect(collapseItems[0].classes()).not.toContain('-rotate-90')
+    })
+  })
+
+  describe('Methods', () => {
+    describe('toggleItem', () => {
+      const TestConsumer = {
+        template: '<div></div>',
+        setup() {
+          return { itemStates: inject('itemStates') }
+        }
+      }
+
+      it('should do nothing if id is undefined', () => {
+        wrapper = mount(VkCollapse, {
+          slots: { default: TestConsumer }
+        })
+
+        const consumer = wrapper.findComponent(TestConsumer)
+        const { toggleItem, items } = consumer.vm.itemStates
+
+        expect(() => toggleItem(undefined)).not.toThrow()
+        expect(Object.keys(items).length).toBe(0)
+      })
+
+      it('should open a closed item (not multiple)', () => {
+        wrapper = mount(VkCollapse, {
+          slots: { default: TestConsumer }
+        })
+
+        const consumer = wrapper.findComponent(TestConsumer)
+        const { toggleItem, items } = consumer.vm.itemStates
+        toggleItem('foo')
+
+        expect(items['foo']).toBe(true)
+      })
+
+      it('should close the item if already open (not multiple)', () => {
+        wrapper = mount(VkCollapse, {
+          slots: { default: TestConsumer }
+        })
+
+        const consumer = wrapper.findComponent(TestConsumer)
+        const { toggleItem, items } = consumer.vm.itemStates
+        toggleItem('foo')
+        toggleItem('foo')
+
+        expect(items['foo']).toBe(false)
+      })
     })
   })
 })

--- a/packages/valko-ui-components/src/__test__/CollapseItem.spec.ts
+++ b/packages/valko-ui-components/src/__test__/CollapseItem.spec.ts
@@ -201,4 +201,14 @@ describe('CollapseItem component', () => {
       })
     })
   })
+
+  describe('Rendering', () => {
+    it('renders and uses fallback when not inside VkCollapse', () => {
+      const wrapper = mount(VkCollapseItem, {
+        props: { title: 'Test' }
+      })
+
+      expect(wrapper.exists()).toBe(true)
+    })
+  })
 })

--- a/packages/valko-ui-components/src/__test__/CollapseItem.spec.ts
+++ b/packages/valko-ui-components/src/__test__/CollapseItem.spec.ts
@@ -211,4 +211,18 @@ describe('CollapseItem component', () => {
       expect(wrapper.exists()).toBe(true)
     })
   })
+
+  describe('Inject', () => {
+    it('should use fallback toggleItem when not injected', async () => {
+      const wrapper = mount(VkCollapseItem, {
+        props: {
+          title: 'Test'
+        }
+      })
+
+      await wrapper.find('button').trigger('click')
+
+      expect(wrapper.find('.vk-collapse-item__panel').exists()).toBe(false)
+    })
+  })
 })

--- a/packages/valko-ui-components/src/__test__/DataTable.spec.ts
+++ b/packages/valko-ui-components/src/__test__/DataTable.spec.ts
@@ -543,6 +543,10 @@ describe('DataTable component', () => {
         })
       })
 
+      afterEach(() => {
+        vi.useRealTimers()
+      })
+
       it('should display the search icon in the header when true', () => {
         expect(wrapper.find('i.ti.ti-search').exists()).toBe(true)
       })
@@ -556,9 +560,12 @@ describe('DataTable component', () => {
       })
 
       it('should emit onFilter when the filter is being used', async () => {
-        wrapper.find('i.ti.ti-search').trigger('click')
-        wrapper.findComponent(VkInput).trigger('input')
-        await new Promise(resolve => setTimeout(resolve, 500))
+        vi.useFakeTimers()
+        await wrapper.find('i.ti.ti-search').trigger('click')
+        await wrapper.findComponent(VkInput).setValue('some filter')
+        await nextTick()
+        vi.advanceTimersByTime(500)
+        await nextTick()
 
         expect(wrapper.emitted()).toHaveProperty('onFilter')
       })
@@ -567,7 +574,7 @@ describe('DataTable component', () => {
         await wrapper.find('i.ti.ti-search').trigger('click')
         await document.body.click()
 
-        expect(wrapper.find('[data-isOpen-state=true]').exists()).toBe(false)
+        expect(wrapper.find('.vk-popover[data-open="true"]').exists()).toBe(false)
       })
     })
 

--- a/packages/valko-ui-components/src/__test__/DataTable.spec.ts
+++ b/packages/valko-ui-components/src/__test__/DataTable.spec.ts
@@ -4,6 +4,7 @@ import VkDataTable from '#valkoui/components/DataTable.vue'
 import VkInput from '#valkoui/components/Input.vue'
 import VkSelect from '#valkoui/components/Select.vue'
 import VkPagination from '#valkoui/components/Pagination.vue'
+import type { Sort } from '#valkoui/types/common'
 
 const headers = [
   {
@@ -39,398 +40,595 @@ const data = [
 describe('DataTable component', () => {
   let wrapper: VueWrapper
 
-  describe('When no extra functionality is added', () => {
-    describe('Props', () => {
-      describe('With default props', () => {
+  describe('Props', () => {
+    describe('With default props', () => {
+      beforeEach(() => {
+        wrapper = mount(VkDataTable, {
+          props: {
+            headers,
+            data
+          }
+        })
+      })
+
+      it('should render', () => {
+        expect(wrapper.find('.vk-data-table').exists()).toBe(true)
+      })
+
+      it('should be size md', () => {
+        expect(wrapper.find('.text-base').exists()).toBe(true)
+      })
+
+      it('should be variant filled', () => {
+        expect(wrapper.find('.bg-surface-container-low').exists()).toBe(true)
+      })
+
+      it('should be shape soft', () => {
+        expect(wrapper.find('.rounded-lg').exists()).toBe(true)
+      })
+    })
+
+    describe('When shape prop changes', () => {
+      it('should be rounded when props.shape is rounded', () => {
+        wrapper = mount(VkDataTable, {
+          props: {
+            headers,
+            data,
+            shape: 'rounded'
+          }
+        })
+
+        expect(wrapper.find('.rounded-xl').exists()).toBe(true)
+      })
+
+      it('should be soft when props.shape is soft', () => {
+        wrapper = mount(VkDataTable, {
+          props: {
+            headers,
+            data,
+            shape: 'soft'
+          }
+        })
+
+        expect(wrapper.find('.rounded-lg').exists()).toBe(true)
+      })
+
+      it('should be square when props.shape is square', () => {
+        wrapper = mount(VkDataTable, {
+          props: {
+            headers,
+            data,
+            shape: 'square'
+          }
+        })
+
+        expect(wrapper.find('.rounded-none').exists()).toBe(true)
+      })
+    })
+
+    describe('When size prop changes', () => {
+      it('should be xs when props.size is xs', () => {
+        wrapper = mount(VkDataTable, {
+          props: {
+            headers,
+            data,
+            size: 'xs'
+          }
+        })
+
+        expect(wrapper.find('.text-xs').exists()).toBe(true)
+      })
+
+      it('should be sm when props.size is sm', () => {
+        wrapper = mount(VkDataTable, {
+          props: {
+            headers,
+            data,
+            size: 'sm'
+          }
+        })
+
+        expect(wrapper.find('.text-sm').exists()).toBe(true)
+      })
+
+      it('should be md when props.size is md', () => {
+        wrapper = mount(VkDataTable, {
+          props: {
+            headers,
+            data,
+            size: 'md'
+          }
+        })
+
+        expect(wrapper.find('.text-base').exists()).toBe(true)
+      })
+
+      it('should be lg when props.size is lg', () => {
+        wrapper = mount(VkDataTable, {
+          props: {
+            headers,
+            data,
+            size: 'lg'
+          }
+        })
+
+        expect(wrapper.find('.text-lg').exists()).toBe(true)
+      })
+    })
+
+    describe('When variant prop changes', () => {
+      it('should be filled when props.variant is filled', () => {
+        wrapper = mount(VkDataTable, {
+          props: {
+            headers,
+            data,
+            variant: 'filled'
+          }
+        })
+
+        expect(wrapper.find('.bg-surface-container-low').exists()).toBe(true)
+      })
+
+      it('should be outlined when props.variant is outlined', () => {
+        wrapper = mount(VkDataTable, {
+          props: {
+            headers,
+            data,
+            variant: 'outlined'
+          }
+        })
+
+        expect(wrapper.find('.border-b').exists()).toBe(true)
+      })
+
+      it('should be ghost when props.variant is ghost', () => {
+        wrapper = mount(VkDataTable, {
+          props: {
+            headers,
+            data,
+            variant: 'ghost'
+          }
+        })
+
+        expect(wrapper.find('.vk-table__thead').classes()).toContain('bg-surface-container-highest/[.5]')
+      })
+    })
+
+    describe('When striped prop changes', () => {
+      it('should be striped when true', () => {
+        const wrapper = mount(VkDataTable, {
+          props: {
+            headers,
+            data,
+            striped: true
+          }
+        })
+
+        expect(wrapper.find('.vk-table__tr').classes()).toContain('even:bg-surface-container')
+      })
+    })
+  })
+
+  describe('Methods', () => {
+    describe('selectedItems', () => {
+      it('checks the correct checkboxes when selection is an array', () => {
+        const selectHeaders = [{ key: 'selection', field: 'selection', label: 'Selection' }, ...headers]
+        const wrapper = mount(VkDataTable, {
+          props: {
+            headers: selectHeaders,
+            data,
+            selectionMode: 'multiple',
+            selection: [
+              { key: 'headersKey' },
+              { key: 'dataKey' }
+            ]
+          }
+        })
+
+        expect(wrapper.findAll('.vk-checkbox__container').at(1)?.attributes('aria-checked')).toBe('true')
+      })
+
+      it('checks the correct radio when selection is a single object', () => {
+        const selectHeaders = [{ key: 'selection', field: 'selection', label: 'Selection' }, ...headers]
+        const wrapper = mount(VkDataTable, {
+          props: {
+            headers: selectHeaders,
+            data,
+            selectionMode: 'single',
+            selection: {
+              key: 'headersKey'
+            }
+          }
+        })
+
+        expect(wrapper.findAll('.vk-radio__radio-container').at(0)?.attributes('aria-checked')).toBe('true')
+      })
+    })
+
+    describe('togglePopover', () => {
+      it('should toggle open a popover when a filter inside a header is clicked', async () => {
+        const filterableHeaders = headers.map(header => ({ ...header, filterable: true }))
+        const wrapper = mount(VkDataTable, {
+          props: {
+            headers: filterableHeaders,
+            data
+          }
+        })
+
+        await wrapper.findAll('.vk-data-table__utilities').at(0)?.trigger('click')
+
+        expect(wrapper.find('.vk-popover__panel').exists()).toBe(true)
+      })
+
+      it('should toggle close a popover when a filter inside a header is clicked again', async () => {
+        const filterableHeaders = headers.map(header => ({ ...header, filterable: true }))
+        const wrapper = mount(VkDataTable, {
+          props: {
+            headers: filterableHeaders,
+            data
+          }
+        })
+
+        await wrapper.findAll('.vk-data-table__utilities').at(0)?.trigger('click')
+        await wrapper.findAll('.vk-data-table__utilities').at(0)?.trigger('click')
+
+        expect(wrapper.find('.vk-popover__panel').exists()).toBe(false)
+      })
+    })
+
+    describe('setActiveFilter', () => {
+      it('should set active state to true when a filter input is used', async () => {
+        const filterableHeaders = headers.map(header => ({ ...header, filterable: true }))
+        const wrapper = mount(VkDataTable, {
+          props: {
+            headers: filterableHeaders,
+            data
+          }
+        })
+
+        await wrapper.findAll('.vk-data-table__utilities').at(0)?.trigger('click')
+        await wrapper.findComponent(VkInput).setValue('some filter')
+
+        expect(wrapper.findAll('.vk-data-table__utilities').at(0)?.attributes('data-active')).toBe('true')
+      })
+    })
+
+    describe('isSortActive', () => {
+      it('should set data-active to true for sorted header after click and prop update', async () => {
+        const sortableHeaders = headers.map(header => ({ ...header, sortable: true }))
+        const wrapper = mount(VkDataTable, {
+          props: {
+            headers: sortableHeaders,
+            data,
+            sort: {
+              field: 'required',
+              direction: undefined
+            }
+          }
+        })
+
+        await wrapper.findAll('.vk-data-table__utilities').at(1)?.trigger('click')
+        const newSort = wrapper.emitted('onSort')?.[0]?.[0] as Sort
+        await wrapper.setProps({ sort: newSort })
+        await wrapper.vm.$nextTick()
+
+        expect(wrapper.findAll('.vk-data-table__utilities').at(1)?.attributes('data-active')).toBe('true')
+      })
+    })
+
+    describe('handleSort', () => {
+      it('emits correct sort direction', async () => {
+        const sortableHeaders = headers.map(header => ({ ...header, sortable: true }))
+        wrapper = mount(VkDataTable, {
+          props: {
+            headers: sortableHeaders,
+            data,
+            sort: {
+              field: 'prop',
+              direction: 'asc'
+            }
+          }
+        })
+
+        await wrapper.findAll('.vk-data-table__utilities').at(1)?.trigger('click')
+
+        expect(wrapper.emitted('onSort')?.[0]?.[0]).toEqual({ field: 'prop', direction: 'desc' })
+      })
+
+      it('should emit asc when clicking desc sorted header', async () => {
+        const sortableHeaders = headers.map(header => ({ ...header, sortable: true }))
+        wrapper = mount(VkDataTable, {
+          props: {
+            headers: sortableHeaders,
+            data,
+            sort: {
+              field: 'prop',
+              direction: undefined
+            }
+          }
+        })
+
+        await wrapper.findAll('.vk-data-table__utilities').at(1)?.trigger('click')
+
+        expect(wrapper.emitted('onSort')?.[0]?.[0]).toEqual({ field: 'prop', direction: 'asc' })
+      })
+
+      it('should emit null when clicking desc sorted header', async () => {
+        const sortableHeaders = headers.map(header => ({ ...header, sortable: true }))
+        wrapper = mount(VkDataTable, {
+          props: {
+            headers: sortableHeaders,
+            data,
+            sort: {
+              field: 'prop',
+              direction: 'desc'
+            }
+          }
+        })
+
+        await wrapper.findAll('.vk-data-table__utilities').at(1)?.trigger('click')
+
+        expect(wrapper.emitted('onSort')?.[0]?.[0]).toEqual(null)
+      })
+    })
+  })
+
+  describe('Watchers & Others', () => {
+    it('should reset to first page when data is loaded', async () => {
+      wrapper = mount(VkDataTable, {
+        props: {
+          headers,
+          data: [],
+          limit: 10,
+          offset: 10
+        }
+      })
+
+      await wrapper.setProps({ data })
+      await nextTick()
+
+      expect(wrapper.emitted('onPageChange')?.[0]?.[0]).toBe(0)
+    })
+
+    it('should remove event listeners when the component is unmounted', async () => {
+      const removeSpy = vi.spyOn(document, 'removeEventListener')
+      const wrapper = mount(VkDataTable, {
+        props: {
+          headers,
+          data
+        }
+      })
+
+      wrapper.unmount()
+      expect(removeSpy).toHaveBeenCalledWith('click', expect.any(Function))
+      removeSpy.mockRestore()
+    })
+  })
+
+  describe('Extended features', () => {
+    describe('Drag and Drop', () => {
+      let wrapper: VueWrapper
+      const dragHeaders = [{ key: 'draggable', field: 'draggable', label: '' }, ...headers]
+      beforeEach(() => {
+        wrapper = mount(VkDataTable, {
+          props: {
+            headers: dragHeaders,
+            data
+          }
+        })
+      })
+
+      it('should display the draggable icon for the rows when true', () => {
+        expect(wrapper.find('i.ti.ti-grip-vertical').exists()).toBe(true)
+      })
+
+      it('should emit onDragStart when a row is dragged', () => {
+        wrapper.find('i.ti.ti-grip-vertical').trigger('dragstart')
+        expect(wrapper.emitted()).toHaveProperty('onDragStart')
+      })
+
+      it('should emit onDragOver when a row is dragged over', () => {
+        wrapper.find('i.ti.ti-grip-vertical').trigger('dragover')
+        expect(wrapper.emitted()).toHaveProperty('onDragOver')
+      })
+
+      it('should emit onDrop when a row is dropped over', () => {
+        wrapper.find('i.ti.ti-grip-vertical').trigger('drop')
+        expect(wrapper.emitted()).toHaveProperty('onDrop')
+      })
+    })
+
+    describe('Selection Mode', () => {
+      describe('When selectionMode is single', () => {
+        let wrapper: VueWrapper
+        const selectionHeaders = [{ key: 'selection', field: 'selection', label: 'Selection' }, ...headers]
+        beforeEach(() => {
+          wrapper = mount(VkDataTable, {
+            props: {
+              headers: selectionHeaders,
+              data,
+              selectionMode: 'single'
+            }
+          })
+        })
+
+        it('should display the radio buttons on the rows', () => {
+          expect(wrapper.find('.vk-radio__radio-container').exists()).toBe(true)
+        })
+
+        it('should emit onSelect when a row radio is clicked', () => {
+          wrapper.find('.vk-radio__radio-container').trigger('click')
+          expect(wrapper.emitted()).toHaveProperty('onSelect')
+        })
+      })
+
+      describe('When selectionMode is multiple', () => {
+        let wrapper: VueWrapper
+        const selectionHeaders = [{ key: 'selection', field: 'selection', label: 'Selection' }, ...headers]
+        beforeEach(() => {
+          wrapper = mount(VkDataTable, {
+            props: {
+              headers: selectionHeaders,
+              data,
+              selectionMode: 'multiple'
+            }
+          })
+        })
+
+        it('should display the checkbox buttons on the rows', () => {
+          expect(wrapper.find('.vk-checkbox__container').exists()).toBe(true)
+        })
+
+        it('should emit onSelectAll when the header checkbox is clicked', () => {
+          wrapper.find('.vk-checkbox__container').trigger('click')
+          expect(wrapper.emitted()).toHaveProperty('onSelectAll')
+        })
+
+        it('should emit onSelect when a row checkbox is clicked', () => {
+          const checkboxs = wrapper.findAll('.vk-checkbox__container')
+          checkboxs[1].trigger('click')
+          expect(wrapper.emitted()).toHaveProperty('onSelect')
+        })
+      })
+
+      describe('When selectionMode is rowSingle', () => {
+        let wrapper: VueWrapper
         beforeEach(() => {
           wrapper = mount(VkDataTable, {
             props: {
               headers,
-              data
+              data,
+              rowEvents: true,
+              selectionMode: 'rowSingle'
             }
           })
         })
 
-        it('should render', () => {
-          expect(wrapper.find('.vk-data-table').exists()).toBe(true)
-        })
-
-        it('should be size md', () => {
-          expect(wrapper.find('.text-base').exists()).toBe(true)
-        })
-
-        it('should be variant filled', () => {
-          expect(wrapper.find('.bg-surface-container-low').exists()).toBe(true)
-        })
-
-        it('should be shape soft', () => {
-          expect(wrapper.find('.rounded-lg').exists()).toBe(true)
+        it('should emit onSelect when a row is clicked', () => {
+          wrapper.find('.vk-table__td').trigger('click')
+          expect(wrapper.emitted()).toHaveProperty('onSelect')
         })
       })
 
-      describe('When shape prop changes', () => {
-        it('should be rounded when props.shape is rounded', () => {
+      describe('When selectionMode is rowMultiple', () => {
+        let wrapper: VueWrapper
+        beforeEach(() => {
           wrapper = mount(VkDataTable, {
             props: {
               headers,
               data,
-              shape: 'rounded'
+              rowEvents: true,
+              selectionMode: 'rowMultiple'
             }
           })
-
-          expect(wrapper.find('.rounded-xl').exists()).toBe(true)
         })
 
-        it('should be soft when props.shape is soft', () => {
-          wrapper = mount(VkDataTable, {
-            props: {
-              headers,
-              data,
-              shape: 'soft'
-            }
-          })
-
-          expect(wrapper.find('.rounded-lg').exists()).toBe(true)
-        })
-
-        it('should be square when props.shape is square', () => {
-          wrapper = mount(VkDataTable, {
-            props: {
-              headers,
-              data,
-              shape: 'square'
-            }
-          })
-
-          expect(wrapper.find('.rounded-none').exists()).toBe(true)
-        })
-      })
-
-      describe('When size prop changes', () => {
-        it('should be xs when props.size is xs', () => {
-          wrapper = mount(VkDataTable, {
-            props: {
-              headers,
-              data,
-              size: 'xs'
-            }
-          })
-
-          expect(wrapper.find('.text-xs').exists()).toBe(true)
-        })
-
-        it('should be sm when props.size is sm', () => {
-          wrapper = mount(VkDataTable, {
-            props: {
-              headers,
-              data,
-              size: 'sm'
-            }
-          })
-
-          expect(wrapper.find('.text-sm').exists()).toBe(true)
-        })
-
-        it('should be md when props.size is md', () => {
-          wrapper = mount(VkDataTable, {
-            props: {
-              headers,
-              data,
-              size: 'md'
-            }
-          })
-
-          expect(wrapper.find('.text-base').exists()).toBe(true)
-        })
-
-        it('should be lg when props.size is lg', () => {
-          wrapper = mount(VkDataTable, {
-            props: {
-              headers,
-              data,
-              size: 'lg'
-            }
-          })
-
-          expect(wrapper.find('.text-lg').exists()).toBe(true)
-        })
-      })
-
-      describe('When variant prop changes', () => {
-        it('should be filled when props.variant is filled', () => {
-          wrapper = mount(VkDataTable, {
-            props: {
-              headers,
-              data,
-              variant: 'filled'
-            }
-          })
-
-          expect(wrapper.find('.bg-surface-container-low').exists()).toBe(true)
-        })
-
-        it('should be outlined when props.variant is outlined', () => {
-          wrapper = mount(VkDataTable, {
-            props: {
-              headers,
-              data,
-              variant: 'outlined'
-            }
-          })
-
-          expect(wrapper.find('.border-b').exists()).toBe(true)
-        })
-
-        it('should be ghost when props.variant is ghost', () => {
-          wrapper = mount(VkDataTable, {
-            props: {
-              headers,
-              data,
-              variant: 'ghost'
-            }
-          })
-
-          expect(wrapper.find('.vk-table__thead').classes()).toContain('bg-surface-container-highest/[.5]')
-        })
-      })
-
-      describe('When striped prop changes', () => {
-        it('should be striped when true', () => {
-          const wrapper = mount(VkDataTable, {
-            props: {
-              headers,
-              data,
-              striped: true
-            }
-          })
-
-          expect(wrapper.find('.vk-table__tr').classes()).toContain('even:bg-surface-container')
+        it('should emit onSelect when a row is clicked', () => {
+          wrapper.find('.vk-table__td').trigger('click')
+          expect(wrapper.emitted()).toHaveProperty('onSelect')
         })
       })
     })
-  })
 
-  describe('When drag and drop functionality is added', () => {
-    let wrapper: VueWrapper
-    const dragHeaders = [{ key: 'draggable', field: 'draggable', label: '' }, ...headers]
-    beforeEach(() => {
-      wrapper = mount(VkDataTable, {
-        props: {
-          headers: dragHeaders,
-          data
-        }
-      })
-    })
-    it('should display the draggable icon for the rows when true', () => {
-      expect(wrapper.find('i.ti.ti-grip-vertical').exists()).toBe(true)
-    })
-
-    it('should emit onDragStart when a row is dragged', () => {
-      wrapper.find('i.ti.ti-grip-vertical').trigger('dragstart')
-      expect(wrapper.emitted()).toHaveProperty('onDragStart')
-    })
-
-    it('should emit onDragOver when a row is dragged over', () => {
-      wrapper.find('i.ti.ti-grip-vertical').trigger('dragover')
-      expect(wrapper.emitted()).toHaveProperty('onDragOver')
-    })
-
-    it('should emit onDrop when a row is dropped over', () => {
-      wrapper.find('i.ti.ti-grip-vertical').trigger('drop')
-      expect(wrapper.emitted()).toHaveProperty('onDrop')
-    })
-  })
-
-  describe('When selectionMode functionality is added', () => {
-    describe('When selectionMode is single', () => {
+    describe('Filterable', () => {
       let wrapper: VueWrapper
-      const selectionHeaders = [{ key: 'selection', field: 'selection', label: 'Selection' }, ...headers]
+      const filterHeaders = headers.map(header => ({ ...header, filterable: true }))
+
       beforeEach(() => {
         wrapper = mount(VkDataTable, {
           props: {
-            headers: selectionHeaders,
-            data,
-            selectionMode: 'single'
+            headers: filterHeaders,
+            data
           }
         })
       })
 
-      it('should display the radio buttons on the rows', () => {
-        expect(wrapper.find('.vk-radio__radio-container').exists()).toBe(true)
+      it('should display the search icon in the header when true', () => {
+        expect(wrapper.find('i.ti.ti-search').exists()).toBe(true)
       })
 
-      it('should emit onSelect when a row radio is clicked', () => {
-        wrapper.find('.vk-radio__radio-container').trigger('click')
-        expect(wrapper.emitted()).toHaveProperty('onSelect')
+      it('should apply the active filter style when input is used', async () => {
+        wrapper.find('i.ti.ti-search').trigger('click')
+        const input = wrapper.findComponent(VkInput)
+        await input.setValue('some filter')
+
+        expect(wrapper.find('i.ti.ti-search').classes()).toContain('data-[active=true]:text-primary')
+      })
+
+      it('should emit onFilter when the filter is being used', async () => {
+        wrapper.find('i.ti.ti-search').trigger('click')
+        wrapper.findComponent(VkInput).trigger('input')
+        await new Promise(resolve => setTimeout(resolve, 500))
+
+        expect(wrapper.emitted()).toHaveProperty('onFilter')
+      })
+
+      it('should close all popovers when a click is done outside', async () => {
+        await wrapper.find('i.ti.ti-search').trigger('click')
+        await document.body.click()
+
+        expect(wrapper.find('[data-isOpen-state=true]').exists()).toBe(false)
       })
     })
 
-    describe('When selectionMode is multiple', () => {
+    describe('Sortable', () => {
       let wrapper: VueWrapper
-      const selectionHeaders = [{ key: 'selection', field: 'selection', label: 'Selection' }, ...headers]
-      beforeEach(() => {
+      const sortHeaders = headers.map(header => ({ ...header, sortable: true }))
+
+      it('should display the sort icon in the header when true', () => {
         wrapper = mount(VkDataTable, {
           props: {
-            headers: selectionHeaders,
-            data,
-            selectionMode: 'multiple'
+            headers: sortHeaders,
+            data
           }
         })
+
+        expect(wrapper.find('i.ti.ti-arrows-sort').exists()).toBe(true)
       })
 
-      it('should display the checkbox buttons on the rows', () => {
-        expect(wrapper.find('.vk-checkbox__container').exists()).toBe(true)
-      })
+      it('should emit onSort when the sort icon is clicked', async () => {
+        wrapper = mount(VkDataTable, {
+          props: {
+            headers: sortHeaders,
+            data
+          }
+        })
 
-      it('should emit onSelectAll when the header checkbox is clicked', () => {
-        wrapper.find('.vk-checkbox__container').trigger('click')
-        expect(wrapper.emitted()).toHaveProperty('onSelectAll')
-      })
-
-      it('should emit onSelect when a row checkbox is clicked', () => {
-        const checkboxs = wrapper.findAll('.vk-checkbox__container')
-        checkboxs[1].trigger('click')
-        expect(wrapper.emitted()).toHaveProperty('onSelect')
+        wrapper.find('i.ti.ti-arrows-sort').trigger('click')
+        expect(wrapper.emitted()).toHaveProperty('onSort')
       })
     })
 
-    describe('When selectionMode is rowSingle', () => {
+    describe('Pagination', () => {
       let wrapper: VueWrapper
       beforeEach(() => {
         wrapper = mount(VkDataTable, {
           props: {
             headers,
             data,
-            rowEvents: true,
-            selectionMode: 'rowSingle'
+            total: 10,
+            limit: 2
           }
         })
       })
 
-      it('should emit onSelect when a row is clicked', () => {
-        wrapper.find('.vk-table__td').trigger('click')
-        expect(wrapper.emitted()).toHaveProperty('onSelect')
-      })
-    })
+      it('should emit onLimitChange when the limit is changed using the select', async () => {
+        const select = wrapper.findComponent(VkSelect)
+        select.find('.vk-input__input').trigger('focus')
+        await nextTick()
+        select.find('.vk-select__item:first-child').trigger('click')
+        await nextTick()
 
-    describe('When selectionMode is rowMultiple', () => {
-      let wrapper: VueWrapper
-      beforeEach(() => {
-        wrapper = mount(VkDataTable, {
-          props: {
-            headers,
-            data,
-            rowEvents: true,
-            selectionMode: 'rowMultiple'
-          }
-        })
+        expect(wrapper.emitted()).toHaveProperty('onLimitChange')
       })
 
-      it('should emit onSelect when a row is clicked', () => {
-        wrapper.find('.vk-table__td').trigger('click')
-        expect(wrapper.emitted()).toHaveProperty('onSelect')
+      it('should emit onPageChange when the page is changed', async () => {
+        const pagination = wrapper.findComponent(VkPagination)
+        pagination.find('.vk-pagination__right').trigger('click')
+        await nextTick()
+
+        expect(wrapper.emitted()).toHaveProperty('onPageChange')
       })
-    })
-  })
-
-  describe('When filterable functionality is added', () => {
-    let wrapper: VueWrapper
-    const filterHeaders = headers.map(header => ({ ...header, filterable: true }))
-
-    beforeEach(() => {
-      wrapper = mount(VkDataTable, {
-        props: {
-          headers: filterHeaders,
-          data
-        }
-      })
-    })
-
-    it('should display the search icon in the header when true', () => {
-      expect(wrapper.find('i.ti.ti-search').exists()).toBe(true)
-    })
-
-    it('should apply the active filter style when input is used', async () => {
-      wrapper.find('i.ti.ti-search').trigger('click')
-      const input = wrapper.findComponent(VkInput)
-      await input.setValue('some filter')
-
-      expect(wrapper.find('i.ti.ti-search').classes()).toContain('data-[active=true]:text-primary')
-    })
-
-    it('should emit onFilter when the filter is being used', async () => {
-      wrapper.find('i.ti.ti-search').trigger('click')
-      wrapper.findComponent(VkInput).trigger('input')
-      await new Promise(resolve => setTimeout(resolve, 500))
-
-      expect(wrapper.emitted()).toHaveProperty('onFilter')
-    })
-
-    it('should close all popovers when a click is done outside', async () => {
-      await wrapper.find('i.ti.ti-search').trigger('click')
-      await document.body.click()
-
-      expect(wrapper.find('[data-isOpen-state=true]').exists()).toBe(false)
-    })
-  })
-
-  describe('When sortable functionality is added', () => {
-    let wrapper: VueWrapper
-    const sortHeaders = headers.map(header => ({ ...header, sortable: true }))
-
-    it('should display the sort icon in the header when true', () => {
-      wrapper = mount(VkDataTable, {
-        props: {
-          headers: sortHeaders,
-          data
-        }
-      })
-
-      expect(wrapper.find('i.ti.ti-arrows-sort').exists()).toBe(true)
-    })
-
-    it('should emit onSort when the sort icon is clicked', async () => {
-      wrapper = mount(VkDataTable, {
-        props: {
-          headers: sortHeaders,
-          data
-        }
-      })
-
-      wrapper.find('i.ti.ti-arrows-sort').trigger('click')
-      expect(wrapper.emitted()).toHaveProperty('onSort')
-    })
-  })
-
-  describe('When pagination functionality is added', () => {
-    let wrapper: VueWrapper
-    beforeEach(() => {
-      wrapper = mount(VkDataTable, {
-        props: {
-          headers,
-          data,
-          total: 10,
-          limit: 2
-        }
-      })
-    })
-
-    it('should emit onLimitChange when the limit is changed using the select', async () => {
-      const select = wrapper.findComponent(VkSelect)
-      select.find('.vk-input__input').trigger('focus')
-      await nextTick()
-      select.find('.vk-select__item:first-child').trigger('click')
-      await nextTick()
-
-      expect(wrapper.emitted()).toHaveProperty('onLimitChange')
-    })
-
-    it('should emit onPageChange when the page is changed', async () => {
-      const pagination = wrapper.findComponent(VkPagination)
-      pagination.find('.vk-pagination__right').trigger('click')
-      await nextTick()
-
-      expect(wrapper.emitted()).toHaveProperty('onPageChange')
     })
   })
 })

--- a/packages/valko-ui-components/src/__test__/Datepicker.spec.ts
+++ b/packages/valko-ui-components/src/__test__/Datepicker.spec.ts
@@ -381,6 +381,24 @@ describe('Datepicker component', () => {
     })
   })
 
+  describe('Methods & Listeners', () => {
+    it('should remove event listeners when the component is unmounted', async () => {
+      const removeSpy = vi.spyOn(document, 'removeEventListener')
+      const wrapper = mount(VkDatepicker, {
+        props: {
+          isOpen: true,
+          modelValue,
+          parsedModel,
+          adapter
+        }
+      })
+
+      wrapper.unmount()
+      expect(removeSpy).toHaveBeenCalledWith('mousedown', expect.any(Function), true)
+      removeSpy.mockRestore()
+    })
+  })
+
   describe('Emits', () => {
     it('should emit update:modelValue event', async () => {
       const wrapper = mount(VkDatepicker, {
@@ -411,8 +429,7 @@ describe('Datepicker component', () => {
         }
       })
 
-      const input = wrapper.findAll('.vk-input__input')[0]
-      await input.trigger('focus')
+      await wrapper.findAll('.vk-input__input').at(0)?.trigger('focus')
 
       expect(wrapper.emitted()).toHaveProperty('open')
     })
@@ -432,6 +449,22 @@ describe('Datepicker component', () => {
 
       document.body.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }))
       await nextTick()
+
+      expect(wrapper.emitted()).toHaveProperty('close')
+    })
+
+    it('should emit close when a date is selected', async () => {
+      const wrapper = mount(VkDatepicker, {
+        props: {
+          isOpen: true,
+          modelValue,
+          parsedModel,
+          adapter
+        }
+      })
+
+      await wrapper.findAll('.vk-input__input').at(0)?.trigger('focus')
+      await wrapper.findAll('.vk-calendar__grid-button').at(0)?.trigger('click')
 
       expect(wrapper.emitted()).toHaveProperty('close')
     })

--- a/packages/valko-ui-components/src/__test__/Datepicker.spec.ts
+++ b/packages/valko-ui-components/src/__test__/Datepicker.spec.ts
@@ -410,11 +410,7 @@ describe('Datepicker component', () => {
         }
       })
 
-      const input = wrapper.findAll('.vk-input__input')[0]
-      await input.trigger('focus')
-
-      const button = wrapper.findAll('.vk-calendar__grid-button')[14]
-      await button.trigger('click')
+      await wrapper.findAll('.vk-calendar__grid-button').at(14)?.trigger('click')
 
       expect(wrapper.emitted()).toHaveProperty('update:modelValue')
     })
@@ -422,7 +418,7 @@ describe('Datepicker component', () => {
     it('should emit open when the input is focused', async () => {
       const wrapper = mount(VkDatepicker, {
         props: {
-          isOpen: true,
+          isOpen: false,
           modelValue,
           parsedModel,
           adapter
@@ -437,16 +433,14 @@ describe('Datepicker component', () => {
     it('should emit close when a click occurs outside the root component', async () => {
       const wrapper = mount(VkDatepicker, {
         props: {
-          isOpen: true,
+          isOpen: false,
           modelValue,
           parsedModel,
           adapter
         }
       })
 
-      const input = wrapper.findAll('.vk-input__input')[0]
-      await input.trigger('focus')
-
+      await wrapper.findAll('.vk-input__input').at(0)?.trigger('focus')
       document.body.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }))
       await nextTick()
 
@@ -463,10 +457,25 @@ describe('Datepicker component', () => {
         }
       })
 
-      await wrapper.findAll('.vk-input__input').at(0)?.trigger('focus')
       await wrapper.findAll('.vk-calendar__grid-button').at(0)?.trigger('click')
 
       expect(wrapper.emitted()).toHaveProperty('close')
+    })
+
+    it('should close the datepicker when finalize-selection event is emitted from the calendar', async () => {
+      const wrapper = mount(VkDatepicker, {
+        props: {
+          isOpen: false,
+          modelValue,
+          parsedModel,
+          adapter
+        }
+      })
+
+      await wrapper.findAll('.vk-input__input').at(0)?.trigger('focus')
+      await wrapper.findAll('.vk-calendar__grid-button').at(0)?.trigger('click')
+
+      expect(wrapper.findComponent({ name: 'VkCalendar' }).exists()).toBe(false)
     })
   })
 })

--- a/packages/valko-ui-components/src/__test__/Drawer.spec.ts
+++ b/packages/valko-ui-components/src/__test__/Drawer.spec.ts
@@ -9,7 +9,6 @@ class ResizeObserver {
   disconnect() {return}
 }
 
-// @ts-expect-error: Before it wasnt giving any error now it does, so adding this to ignore it until we can fix it properly.
 global.ResizeObserver = ResizeObserver
 
 describe('Drawer component', () => {

--- a/packages/valko-ui-components/src/__test__/Drawer.spec.ts
+++ b/packages/valko-ui-components/src/__test__/Drawer.spec.ts
@@ -1,5 +1,5 @@
 import { VueWrapper, mount } from '@vue/test-utils'
-import { DialogPanel, Dialog } from '@headlessui/vue'
+import { DialogPanel } from '@headlessui/vue'
 import { nextTick } from 'vue'
 import VkDrawer from '#valkoui/components/Drawer.vue'
 
@@ -16,6 +16,9 @@ describe('Drawer component', () => {
   let drawer: VueWrapper
   let backdrop: VueWrapper
   let panel: VueWrapper
+
+  afterEach(() => document.body.innerHTML = '')
+
   describe('Props', () => {
     describe('With default props', () => {
       beforeEach(async () => {
@@ -478,25 +481,26 @@ describe('Drawer component', () => {
       })
 
       await nextTick()
-      await wrapper.findComponent(DialogStub).trigger('close')
+      await wrapper.findComponent(DialogStub).trigger('click')
 
       expect(wrapper.emitted()).not.toHaveProperty('close')
     })
   })
 
   describe('Arias', () => {
-    it('should use description id for aria-describedby if aria-description is provided', () => {
-      const wrapper = mount(VkDrawer, {
+    it('should use description id for aria-describedby if aria-description is provided', async () => {
+      mount(VkDrawer, {
         props: {
           isOpen: true,
           ariaDescription: 'description-id'
-        }
+        },
+        attachTo: document.body
       })
 
-      const dialog = wrapper.getComponent(Dialog)
-      const id = dialog.attributes('aria-describedby')
+      await nextTick()
 
-      expect(dialog.attributes('aria-describedby')).toBe(id)
+      const dialog = document.querySelector('.vk-drawer__dialog')
+      expect(dialog?.getAttribute('aria-describedby')).toBeTruthy()
     })
   })
 

--- a/packages/valko-ui-components/src/__test__/Drawer.spec.ts
+++ b/packages/valko-ui-components/src/__test__/Drawer.spec.ts
@@ -1,5 +1,5 @@
 import { VueWrapper, mount } from '@vue/test-utils'
-import { DialogPanel } from '@headlessui/vue'
+import { DialogPanel, Dialog } from '@headlessui/vue'
 import { nextTick } from 'vue'
 import VkDrawer from '#valkoui/components/Drawer.vue'
 
@@ -9,6 +9,7 @@ class ResizeObserver {
   disconnect() {return}
 }
 
+// @ts-expect-error: Before it wasnt giving any error now it does, so adding this to ignore it until we can fix it properly.
 global.ResizeObserver = ResizeObserver
 
 describe('Drawer component', () => {
@@ -450,6 +451,53 @@ describe('Drawer component', () => {
       window.dispatchEvent(new Event('click', { bubbles: true }))
 
       expect(wrapper.emitted()).not.toHaveProperty('close')
+    })
+
+    it('should not emit close if closable is false when the dialog close is emited', async () => {
+      const DialogStub = {
+        template: '<div @click="$emit(\'close\')"><slot /></div>'
+      }
+
+      const DialogPanelStub = {
+        template: '<div><slot /></div>'
+      }
+
+      const wrapper = mount(VkDrawer, {
+        props: {
+          isOpen: true,
+          closable: false
+        },
+        slots: {
+          default: 'Hello World'
+        },
+        global: {
+          stubs: {
+            Dialog: DialogStub,
+            DialogPanel: DialogPanelStub
+          }
+        }
+      })
+
+      await nextTick()
+      await wrapper.findComponent(DialogStub).trigger('close')
+
+      expect(wrapper.emitted()).not.toHaveProperty('close')
+    })
+  })
+
+  describe('Arias', () => {
+    it('should use description id for aria-describedby if aria-description is provided', () => {
+      const wrapper = mount(VkDrawer, {
+        props: {
+          isOpen: true,
+          ariaDescription: 'description-id'
+        }
+      })
+
+      const dialog = wrapper.getComponent(Dialog)
+      const id = dialog.attributes('aria-describedby')
+
+      expect(dialog.attributes('aria-describedby')).toBe(id)
     })
   })
 

--- a/packages/valko-ui-components/src/__test__/Dropdown.spec.ts
+++ b/packages/valko-ui-components/src/__test__/Dropdown.spec.ts
@@ -410,6 +410,23 @@ describe('Dropdown component', () => {
     })
   })
 
+  describe('Computeds', () => {
+    describe('open computed', () => {
+      it('should not update internalOpen when isOpen prop is set (controlled)', async () => {
+        const wrapper = mount(VkDropdown, {
+          props: {
+            isOpen: true,
+            items: []
+          }
+        })
+
+        await wrapper.find('.vk-dropdown__trigger-button').trigger('click')
+
+        expect(wrapper.props('isOpen')).toBe(true)
+      })
+    })
+  })
+
   describe('Emits', () => {
     it('should emit click event', async () => {
       const wrapper = mount(VkDropdown, {
@@ -434,6 +451,18 @@ describe('Dropdown component', () => {
       await wrapper.find('.vk-dropdown__item-button').trigger('click')
 
       expect(wrapper.emitted()).not.toHaveProperty('itemClick')
+    })
+
+    it('should close the dropdown when popover emits close', async () => {
+      const wrapper = mount(VkDropdown, {
+        props: { items }
+      })
+
+      await wrapper.find('.vk-dropdown__trigger-button').trigger('click')
+      await wrapper.findComponent({ name: 'VkPopover' }).vm.$emit('close')
+      await flushPromises()
+
+      expect(wrapper.find('.vk-dropdown__items-menu').exists()).toBe(false)
     })
   })
 })

--- a/packages/valko-ui-components/src/__test__/Input.spec.ts
+++ b/packages/valko-ui-components/src/__test__/Input.spec.ts
@@ -1,5 +1,5 @@
 import { nextTick } from 'vue'
-import { VueWrapper, mount } from '@vue/test-utils'
+import { VueWrapper, mount, shallowMount } from '@vue/test-utils'
 import VkInput from '#valkoui/components/Input.vue'
 
 describe('Input component', () => {
@@ -687,6 +687,268 @@ describe('Input component', () => {
         })
 
         expect(wrapper.find('.vk-input__number-arrows').exists()).toBe(false)
+      })
+    })
+  })
+
+  describe('Methods', () => {
+    describe('updateValue', () => {
+      it('emits a number when type is number', async () => {
+        const wrapper = mount(VkInput, {
+          props: {
+            type: 'number',
+            modelValue: ''
+          }
+        })
+
+        const input = wrapper.find('input')
+        await input.setValue('42')
+
+        expect(wrapper.emitted('update:modelValue')?.[0][0]).toBe(42)
+      })
+
+      it('emits empty string when type is number and input is empty', async () => {
+        const wrapper = mount(VkInput, {
+          props: {
+            type: 'number',
+            modelValue: ''
+          }
+        })
+
+        const input = wrapper.find('input')
+        await input.setValue('')
+
+        expect(wrapper.emitted('update:modelValue')?.[0][0]).toBe('')
+      })
+    })
+
+    describe('onFocus', () => {
+      it('should emit focus event when input is focused', async () => {
+        const wrapper = mount(VkInput, {})
+
+        await wrapper.find('.vk-input__input').trigger('focus')
+
+        expect(wrapper.emitted()).toHaveProperty('focus')
+      })
+
+      it('does not emit focus when disabled (direct call for coverage)', () => {
+        const wrapper = shallowMount(VkInput, {
+          props: { disabled: true }
+        })
+
+        // @ts-expect-error: access internal method for coverage since focus event cannot be triggered when native input is disabled
+        wrapper.vm.onFocus(new Event('focus'))
+
+        expect(wrapper.emitted('focus')).toBeFalsy()
+      })
+    })
+
+    describe('onBlur', () => {
+      it('should emit blur event when input is blurred', async () => {
+        const wrapper = mount(VkInput, {})
+
+        await wrapper.find('.vk-input__input').trigger('blur')
+
+        expect(wrapper.emitted()).toHaveProperty('blur')
+      })
+
+      it('should not emit blur when disabled (direct call for coverage)', () => {
+        const wrapper = shallowMount(VkInput, {
+          props: { disabled: true }
+        })
+
+        // @ts-expect-error: access internal method for coverage since blur event cannot be triggered when native input is disabled
+        wrapper.vm.onBlur(new Event('blur'))
+
+        expect(wrapper.emitted('blur')).toBeFalsy()
+      })
+    })
+
+    describe('handleIconClick', () => {
+      it('should do nothing when disabled is true', async () => {
+        const wrapper = shallowMount(VkInput, {
+          props: {
+            disabled: true
+          },
+          slots: {
+            'left-icon': '<i class="ti ti-brand-vue"></i>'
+          }
+        })
+
+        await wrapper.findAll('.vk-input__icons').at(0)?.trigger('click')
+
+        expect(wrapper.emitted('leftIconClick')).toBeFalsy()
+      })
+
+      it('should emit leftIconClick on touchend', async () => {
+        const wrapper = mount(VkInput, {
+          slots: {
+            'left-icon': '<i class="ti ti-brand-vue"></i>'
+          }
+        })
+
+        await wrapper.findAll('.vk-input__icons').at(0)?.trigger('touchend')
+
+        expect(wrapper.emitted('leftIconClick')).toBeTruthy()
+      })
+
+      it('should emit rightIconClick on touchend', async () => {
+        const wrapper = mount(VkInput, {
+          slots: {
+            'right-icon': '<i class="ti ti-brand-vue"></i>'
+          }
+        })
+
+        await wrapper.findAll('.vk-input__icons').at(0)?.trigger('touchend')
+
+        expect(wrapper.emitted('rightIconClick')).toBeTruthy()
+      })
+    })
+
+    describe('changeNumericValue', () => {
+      it('should not change value when type is not number', async () => {
+        const wrapper = mount(VkInput, {
+          props: {
+            type: 'text',
+            modelValue: 'Hello'
+          }
+        })
+
+        // @ts-expect-error: access internal method for coverage since arrow buttons are not rendered when type is not number
+        wrapper.vm.changeNumericValue(1)
+        await nextTick()
+
+        expect(wrapper.emitted('update:modelValue')).toBeUndefined()
+      })
+
+      it('should not change value when readonly is true', async () => {
+        const wrapper = mount(VkInput, {
+          props: {
+            type: 'number',
+            modelValue: 10,
+            readonly: true
+          }
+        })
+
+        await wrapper.findAll('.vk-input__number-arrows').at(0)?.trigger('click')
+
+        expect(wrapper.emitted('update:modelValue')).toBeUndefined()
+      })
+
+      it('should not change value when disabled is true', async () => {
+        const wrapper = mount(VkInput, {
+          props: {
+            type: 'number',
+            modelValue: 10,
+            disabled: true
+          }
+        })
+
+        await wrapper.findAll('.vk-input__number-arrows').at(0)?.trigger('click')
+
+        expect(wrapper.emitted('update:modelValue')).toBeUndefined()
+      })
+
+      it('should not change value when the new value would be less than min', async () => {
+        const wrapper = mount(VkInput, {
+          props: {
+            type: 'number',
+            modelValue: 0,
+            min: 0
+          }
+        })
+
+        // @ts-expect-error: access internal method for coverage
+        wrapper.vm.changeNumericValue(-1)
+        await nextTick()
+
+        expect(wrapper.emitted('update:modelValue')).toBeUndefined()
+      })
+
+      it('should not change value when the new value would be more than max', async () => {
+        const wrapper = mount(VkInput, {
+          props: {
+            type: 'number',
+            modelValue: 10,
+            max: 10
+          }
+        })
+
+        await wrapper.findAll('.vk-input__number-arrows').at(0)?.trigger('click')
+
+        expect(wrapper.emitted('update:modelValue')).toBeUndefined()
+      })
+    })
+
+    describe('handleNumericArrowRelease', () => {
+      it('remove touchend listener on arrow release', async () => {
+        const removeEventListenerSpy = vi.spyOn(window, 'removeEventListener')
+        const wrapper = mount(VkInput, {
+          props: {
+            type: 'number'
+          }
+        })
+
+        await wrapper.find('i.ti.ti-chevron-up').trigger('mouseup')
+
+        expect(removeEventListenerSpy).toHaveBeenCalledWith('touchend', expect.any(Function))
+        removeEventListenerSpy.mockRestore()
+      })
+
+      it('remove touchcancel listener on arrow release', async () => {
+        const removeEventListenerSpy = vi.spyOn(window, 'removeEventListener')
+        const wrapper = mount(VkInput, {
+          props: {
+            type: 'number'
+          }
+        })
+
+        await wrapper.find('i.ti.ti-chevron-up').trigger('mouseup')
+
+        expect(removeEventListenerSpy).toHaveBeenCalledWith('touchcancel', expect.any(Function))
+        removeEventListenerSpy.mockRestore()
+      })
+    })
+
+    describe('describedBy', () => {
+      it('should add aria-describedby when is given', () => {
+        const wrapper = mount(VkInput, {
+          props: {
+            ariaDescribedBy: 'helper-text-id'
+          }
+        })
+
+        expect(wrapper.find('.vk-input__input').attributes('aria-describedby')).toBe('helper-text-id')
+      })
+    })
+
+    describe('handleNumericArrowHold', () => {
+      it('should trigger on touchstart (increment)', async () => {
+        vi.useFakeTimers()
+        const wrapper = mount(VkInput, {
+          props: {
+            type: 'number',
+            modelValue: 1
+          }
+        })
+
+        await wrapper.find('i.ti.ti-chevron-up').trigger('touchstart')
+        vi.advanceTimersByTime(300)
+        expect(wrapper.emitted('update:modelValue')?.[2]).toEqual([4])
+      })
+
+      it('should trigger on touchstart (decrement)', async () => {
+        vi.useFakeTimers()
+        const wrapper = mount(VkInput, {
+          props: {
+            type: 'number',
+            modelValue: 10
+          }
+        })
+
+        await wrapper.find('i.ti.ti-chevron-down').trigger('touchstart')
+        vi.advanceTimersByTime(300)
+        expect(wrapper.emitted('update:modelValue')?.[2]).toEqual([7])
       })
     })
   })

--- a/packages/valko-ui-components/src/__test__/Input.spec.ts
+++ b/packages/valko-ui-components/src/__test__/Input.spec.ts
@@ -4,6 +4,11 @@ import VkInput from '#valkoui/components/Input.vue'
 
 describe('Input component', () => {
   let wrapper: VueWrapper
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
   describe('Props', () => {
     describe('With default props', () => {
       beforeEach(() => {
@@ -497,7 +502,6 @@ describe('Input component', () => {
 
     describe('startHolding and stopHolding functionality', () => {
       it('should emit update:modelValue with a higher value when holding the up arrow', async () => {
-        vi.clearAllTimers()
         vi.useFakeTimers()
         const wrapper = mount(VkInput, {
           props: {
@@ -535,7 +539,6 @@ describe('Input component', () => {
         const emittedAfter = wrapper.emitted('update:modelValue') as string[][]
 
         expect(emittedAfter[emittedAfter.length - 1]).toEqual([lastValue])
-        vi.useRealTimers()
       })
     })
 

--- a/packages/valko-ui-components/src/__test__/Menu.spec.ts
+++ b/packages/valko-ui-components/src/__test__/Menu.spec.ts
@@ -1,6 +1,7 @@
 import { VueWrapper, mount } from '@vue/test-utils'
 import VkMenu from '#valkoui/components/Menu.vue'
 import { MenuItem } from '#valkoui/types/Menu.ts'
+import { nextTick } from 'vue'
 
 describe('Menu component', () => {
   const onClickMock = vi.fn()
@@ -327,6 +328,239 @@ describe('Menu component', () => {
       await items[0].trigger('click')
 
       expect(wrapper.emitted()).toHaveProperty('itemClick')
+    })
+  })
+
+  describe('Items logic', () => {
+    describe('Groups', () => {
+      it('should set group to default is not group is provided', () => {
+        const items: MenuItem[] = [
+          { key: 'no-group', text: 'No Group' }
+        ]
+
+        wrapper = mount(VkMenu, {
+          props: {
+            items,
+            active: 0
+          }
+        })
+
+        expect(wrapper.find('.vk-menu__group').exists()).toBe(false)
+      })
+
+      it('should set group to provided group name', () => {
+        const items: MenuItem[] = [
+          { key: 'with-group', group: 'Custom Group', text: 'With Group' }
+        ]
+
+        wrapper = mount(VkMenu, {
+          props: {
+            items,
+            active: 0
+          }
+        })
+
+        expect(wrapper.find('.vk-menu__group').text()).toBe('Custom Group')
+      })
+    })
+
+    describe('Watcher DOM behavior', () => {
+      it('should focus the item matching active prop', async () => {
+        wrapper = mount(VkMenu, {
+          props: {
+            items: menuItems,
+            active: 'button'
+          }
+        })
+
+        await nextTick()
+        const buttons = wrapper.findAll('.vk-menu__content')
+
+        expect(buttons[2].attributes('tabindex')).toBe('0')
+      })
+
+      it('should focus the first item if active does not match any key', async () => {
+        wrapper = mount(VkMenu, {
+          props: {
+            items: menuItems,
+            active: 'non-existent-key'
+          }
+        })
+
+        await nextTick()
+        const buttons = wrapper.findAll('.vk-menu__content')
+
+        expect(buttons[0].attributes('tabindex')).toBe('0')
+      })
+
+      it('should not focus any item if all are disabled', async () => {
+        const items = [
+          { key: 'a', text: 'A', disabled: true },
+          { key: 'b', text: 'B', disabled: true }
+        ]
+
+        wrapper = mount(VkMenu, {
+          props: { items, active: 'a' }
+        })
+
+        await nextTick()
+        const buttons = wrapper.findAll('.vk-menu__content')
+
+        buttons.forEach(button => {
+          expect(button.attributes('tabindex')).toBe('-1')
+        })
+      })
+    })
+
+    describe('onKeyDown', () => {
+      it('should move focus with ArrowDown', async () => {
+        wrapper = mount(VkMenu, {
+          props: {
+            items: menuItems,
+            active: 'get-started'
+          }
+        })
+
+        await nextTick()
+        const buttons = wrapper.findAll('.vk-menu__content')
+        await buttons[0].trigger('keydown', { key: 'ArrowDown' })
+        await nextTick()
+
+        expect(buttons[2].attributes('tabindex')).toBe('0')
+      })
+
+      it('should move focus with ArrowUp', async () => {
+        wrapper = mount(VkMenu, {
+          props: {
+            items: menuItems,
+            active: 'get-started'
+          }
+        })
+
+        await nextTick()
+        const buttons = wrapper.findAll('.vk-menu__content')
+        await buttons[0].trigger('keydown', { key: 'End' })
+        await nextTick()
+        await buttons[2].trigger('keydown', { key: 'ArrowUp' })
+        await nextTick()
+
+        expect(buttons[0].attributes('tabindex')).toBe('0')
+      })
+
+      it('should move focus with Home', async () => {
+        wrapper = mount(VkMenu, {
+          props: {
+            items: menuItems,
+            active: 'get-started'
+          }
+        })
+
+        await nextTick()
+        const buttons = wrapper.findAll('.vk-menu__content')
+        await buttons[0].trigger('keydown', { key: 'End' })
+        await nextTick()
+        await buttons[2].trigger('keydown', { key: 'Home' })
+        await nextTick()
+
+        expect(buttons[0].attributes('tabindex')).toBe('0')
+      })
+
+      it('should move focus with End', async () => {
+        wrapper = mount(VkMenu, {
+          props: {
+            items: menuItems,
+            active: 'get-started'
+          }
+        })
+
+        await nextTick()
+        const buttons = wrapper.findAll('.vk-menu__content')
+        await buttons[0].trigger('keydown', { key: 'End' })
+        await nextTick()
+
+        expect(buttons[2].attributes('tabindex')).toBe('0')
+      })
+
+      it('should trigger click with Enter if not disabled', async () => {
+        wrapper = mount(VkMenu, {
+          props: {
+            items: menuItems,
+            active: 'get-started'
+          }
+        })
+
+        await nextTick()
+        const buttons = wrapper.findAll('.vk-menu__content')
+        onClickMock.mockClear()
+        await buttons[0].trigger('keydown', { key: 'Enter' })
+
+        expect(onClickMock).toHaveBeenCalledTimes(1)
+      })
+
+      it('should trigger click with SpaceBar if not disabled', async () => {
+        wrapper = mount(VkMenu, {
+          props: {
+            items: menuItems,
+            active: 'get-started'
+          }
+        })
+
+        await nextTick()
+        const buttons = wrapper.findAll('.vk-menu__content')
+        onClickMock.mockClear()
+        await buttons[0].trigger('keydown', { key: 'SpaceBar' })
+
+        expect(onClickMock).toHaveBeenCalledTimes(1)
+      })
+
+      it('should not trigger click with Enter if disabled', async () => {
+        wrapper = mount(VkMenu, {
+          props: {
+            items: menuItems,
+            active: 'divider'
+          }
+        })
+
+        await nextTick()
+        const buttons = wrapper.findAll('.vk-menu__content')
+        onClickMock.mockClear()
+        await buttons[1].trigger('keydown', { key: 'Enter' })
+
+        expect(onClickMock).not.toHaveBeenCalled()
+      })
+
+      it('should not trigger click with SpaceBar if disabled', async () => {
+        wrapper = mount(VkMenu, {
+          props: {
+            items: menuItems,
+            active: 'divider'
+          }
+        })
+
+        await nextTick()
+        const buttons = wrapper.findAll('.vk-menu__content')
+        onClickMock.mockClear()
+        await buttons[1].trigger('keydown', { key: 'SpaceBar' })
+
+        expect(onClickMock).not.toHaveBeenCalled()
+      })
+
+      it('should do nothing for unrelated keys', async () => {
+        wrapper = mount(VkMenu, {
+          props: {
+            items: menuItems,
+            active: 'get-started'
+          }
+        })
+
+        await nextTick()
+        const buttons = wrapper.findAll('.vk-menu__content')
+        onClickMock.mockClear()
+        await buttons[0].trigger('keydown', { key: 'Tab' })
+        expect(onClickMock).not.toHaveBeenCalled()
+
+        expect(buttons[0].attributes('tabindex')).toBe('0')
+      })
     })
   })
 })

--- a/packages/valko-ui-components/src/__test__/Menu.spec.ts
+++ b/packages/valko-ui-components/src/__test__/Menu.spec.ts
@@ -561,6 +561,28 @@ describe('Menu component', () => {
 
         expect(buttons[0].attributes('tabindex')).toBe('0')
       })
+
+      it('focuses the correct menu item after keyboard navigation and activation', async () => {
+        wrapper = mount(VkMenu, {
+          props: {
+            items: menuItems,
+            active: 'get-started'
+          },
+          attachTo: document.body
+        })
+
+        await nextTick()
+        const buttons = wrapper.findAll('[role="menuitem"]')
+        await buttons[0].trigger('keydown', { key: 'ArrowDown' })
+        await nextTick()
+        const focused = buttons.find(b => b.attributes('tabindex') === '0')
+        await focused!.trigger('keydown', { key: 'Enter' })
+        const focusedIndex = buttons.findIndex(b => b === focused)
+        await wrapper.setProps({ active: menuItems[focusedIndex].key })
+        await nextTick()
+
+        expect(focused!.attributes('data-active')).toContain('true')
+      })
     })
   })
 })

--- a/packages/valko-ui-components/src/__test__/Modal.spec.ts
+++ b/packages/valko-ui-components/src/__test__/Modal.spec.ts
@@ -1,5 +1,5 @@
 import { VueWrapper, mount } from '@vue/test-utils'
-import { DialogPanel } from '@headlessui/vue'
+import { DialogPanel, Dialog } from '@headlessui/vue'
 import { nextTick } from 'vue'
 import VkModal from '#valkoui/components/Modal.vue'
 
@@ -9,6 +9,7 @@ class ResizeObserver {
   disconnect() {return}
 }
 
+// @ts-expect-error: Before it wasnt giving any error now it does, so adding this to ignore it until we can fix it properly.
 global.ResizeObserver = ResizeObserver
 
 describe('Modal component', () => {
@@ -355,6 +356,22 @@ describe('Modal component', () => {
     })
   })
 
+  describe('Arias', () => {
+    it('should use description id for aria-describedby if aria-description is provided', () => {
+      const wrapper = mount(VkModal, {
+        props: {
+          isOpen: true,
+          ariaDescription: 'description-id'
+        }
+      })
+
+      const dialog = wrapper.getComponent(Dialog)
+      const id = dialog.attributes('aria-describedby')
+
+      expect(dialog.attributes('aria-describedby')).toBe(id)
+    })
+  })
+
   describe('Emits', () => {
     it('should emit close event', async () => {
       const wrapper = mount(VkModal, {
@@ -370,6 +387,37 @@ describe('Modal component', () => {
       modal = wrapper.getComponent(DialogPanel) as unknown as VueWrapper
       modal.find('i.ti.ti-x').trigger('click')
       expect(wrapper.emitted()).toHaveProperty('close')
+    })
+
+    it('should not emit close if closable is false when the dialog close is emited', async () => {
+      const DialogStub = {
+        template: '<div @click="$emit(\'close\')"><slot /></div>'
+      }
+
+      const DialogPanelStub = {
+        template: '<div><slot /></div>'
+      }
+
+      const wrapper = mount(VkModal, {
+        props: {
+          isOpen: true,
+          closable: false
+        },
+        slots: {
+          default: 'Hello World'
+        },
+        global: {
+          stubs: {
+            Dialog: DialogStub,
+            DialogPanel: DialogPanelStub
+          }
+        }
+      })
+
+      await nextTick()
+      await wrapper.findComponent(DialogStub).trigger('close')
+
+      expect(wrapper.emitted()).not.toHaveProperty('close')
     })
   })
 })

--- a/packages/valko-ui-components/src/__test__/Modal.spec.ts
+++ b/packages/valko-ui-components/src/__test__/Modal.spec.ts
@@ -9,7 +9,6 @@ class ResizeObserver {
   disconnect() {return}
 }
 
-// @ts-expect-error: Before it wasnt giving any error now it does, so adding this to ignore it until we can fix it properly.
 global.ResizeObserver = ResizeObserver
 
 describe('Modal component', () => {

--- a/packages/valko-ui-components/src/__test__/Modal.spec.ts
+++ b/packages/valko-ui-components/src/__test__/Modal.spec.ts
@@ -1,5 +1,5 @@
 import { VueWrapper, mount } from '@vue/test-utils'
-import { DialogPanel, Dialog } from '@headlessui/vue'
+import { DialogPanel } from '@headlessui/vue'
 import { nextTick } from 'vue'
 import VkModal from '#valkoui/components/Modal.vue'
 
@@ -15,6 +15,9 @@ describe('Modal component', () => {
   let wrapper: VueWrapper
   let modal: VueWrapper
   let backdrop: VueWrapper
+
+  afterEach(() => document.body.innerHTML = '')
+
   describe('Props', () => {
     describe('With default props', () => {
       beforeEach(async () => {
@@ -356,18 +359,19 @@ describe('Modal component', () => {
   })
 
   describe('Arias', () => {
-    it('should use description id for aria-describedby if aria-description is provided', () => {
-      const wrapper = mount(VkModal, {
+    it('should use description id for aria-describedby if aria-description is provided', async () => {
+      mount(VkModal, {
         props: {
           isOpen: true,
-          ariaDescription: 'description-id'
-        }
+          ariaDescription: 'Some description'
+        },
+        attachTo: document.body
       })
 
-      const dialog = wrapper.getComponent(Dialog)
-      const id = dialog.attributes('aria-describedby')
+      await nextTick()
 
-      expect(dialog.attributes('aria-describedby')).toBe(id)
+      const dialog = document.querySelector('.vk-modal__dialog')
+      expect(dialog?.getAttribute('aria-describedby')).toBeTruthy()
     })
   })
 
@@ -414,7 +418,7 @@ describe('Modal component', () => {
       })
 
       await nextTick()
-      await wrapper.findComponent(DialogStub).trigger('close')
+      await wrapper.findComponent(DialogStub).trigger('click')
 
       expect(wrapper.emitted()).not.toHaveProperty('close')
     })

--- a/packages/valko-ui-components/src/__test__/Popover.spec.ts
+++ b/packages/valko-ui-components/src/__test__/Popover.spec.ts
@@ -220,7 +220,7 @@ describe('Popover component', () => {
     })
 
     describe('placement', () => {
-      it('should use the passed aligment prop if present', () => {
+      it('should use the passed alignment prop if present', () => {
         wrapper = mount(VkPopover, {
           props: {
             isOpen: true,

--- a/packages/valko-ui-components/src/__test__/Popover.spec.ts
+++ b/packages/valko-ui-components/src/__test__/Popover.spec.ts
@@ -219,41 +219,17 @@ describe('Popover component', () => {
       removeSpy.mockRestore()
     })
 
-    // describe('placement', () => {
-    //   it('sets data-placement to left-start when no placement fits (auto)', async () => {
-    //     const wrapper = mount(VkPopover, {
-    //       props: { isOpen: true },
-    //       slots: { 'popover-content': 'Hello Content' }
-    //     })
-
-    //     // Wait for refs to be set
-    //     await wrapper.vm.$nextTick()
-    //     await wrapper.vm.$nextTick()
-
-    //     // Access refs
-    //     // @ts-expect-error: access internal refs for testing
-    //     const slot = wrapper.vm.slotRef
-    //     // @ts-expect-error: access internal refs for testing
-    //     const panel = wrapper.vm.panelRef
-
-    //     // Ensure refs are present
-    //     expect(slot).not.toBeNull()
-    //     expect(panel).not.toBeNull()
-
-    //     // Mock getBoundingClientRect
-    //     Object.defineProperty(slot, 'getBoundingClientRect', {
-    //       value: () => ({ bottom: 0, top: 0, left: 0, right: 0, height: 0, width: 0 })
-    //     })
-    //     Object.defineProperty(panel, 'getBoundingClientRect', {
-    //       value: () => ({ height: 1000, width: 1000 })
-    //     })
-
-    //     await wrapper.vm.$forceUpdate()
-    //     await wrapper.vm.$nextTick()
-
-    //     expect(wrapper.find('.vk-popover__panel').attributes('data-placement')).toBe('left-start')
-    //   })
-    // })
+    describe('placement', () => {
+      it('should use the passed aligment prop if present', () => {
+        wrapper = mount(VkPopover, {
+          props: {
+            isOpen: true,
+            alignment: 'start'
+          }
+        })
+        expect(wrapper.find('.vk-popover__panel').attributes('data-placement')).toContain('start')
+      })
+    })
   })
 
   describe('Emits', () => {

--- a/packages/valko-ui-components/src/__test__/Popover.spec.ts
+++ b/packages/valko-ui-components/src/__test__/Popover.spec.ts
@@ -205,7 +205,58 @@ describe('Popover component', () => {
     })
   })
 
-  describe('Events', () => {
+  describe('Methods & Listeners', () => {
+    it('should remove event listeners when the component is unmounted', async () => {
+      const removeSpy = vi.spyOn(document, 'removeEventListener')
+      const wrapper = mount(VkPopover, {
+        props: {
+          isOpen: true
+        }
+      })
+
+      wrapper.unmount()
+      expect(removeSpy).toHaveBeenCalledWith('click', expect.any(Function))
+      removeSpy.mockRestore()
+    })
+
+    // describe('placement', () => {
+    //   it('sets data-placement to left-start when no placement fits (auto)', async () => {
+    //     const wrapper = mount(VkPopover, {
+    //       props: { isOpen: true },
+    //       slots: { 'popover-content': 'Hello Content' }
+    //     })
+
+    //     // Wait for refs to be set
+    //     await wrapper.vm.$nextTick()
+    //     await wrapper.vm.$nextTick()
+
+    //     // Access refs
+    //     // @ts-expect-error: access internal refs for testing
+    //     const slot = wrapper.vm.slotRef
+    //     // @ts-expect-error: access internal refs for testing
+    //     const panel = wrapper.vm.panelRef
+
+    //     // Ensure refs are present
+    //     expect(slot).not.toBeNull()
+    //     expect(panel).not.toBeNull()
+
+    //     // Mock getBoundingClientRect
+    //     Object.defineProperty(slot, 'getBoundingClientRect', {
+    //       value: () => ({ bottom: 0, top: 0, left: 0, right: 0, height: 0, width: 0 })
+    //     })
+    //     Object.defineProperty(panel, 'getBoundingClientRect', {
+    //       value: () => ({ height: 1000, width: 1000 })
+    //     })
+
+    //     await wrapper.vm.$forceUpdate()
+    //     await wrapper.vm.$nextTick()
+
+    //     expect(wrapper.find('.vk-popover__panel').attributes('data-placement')).toBe('left-start')
+    //   })
+    // })
+  })
+
+  describe('Emits', () => {
     it('should emit close when clicking outside', async () => {
       wrapper = mount(VkPopover, {
         props: { isOpen: true },

--- a/packages/valko-ui-components/src/__test__/Progressbar.spec.ts
+++ b/packages/valko-ui-components/src/__test__/Progressbar.spec.ts
@@ -333,6 +333,31 @@ describe('Progressbar component', () => {
         const progress = wrapper.find('.vk-progressbar__stripes')
         expect(progress.attributes('style')).toContain('background-image')
       })
+
+      it('stripeStyles returns undefined for backgroundImage when striped is false', () => {
+        const wrapper = mount(VkProgressbar, {
+          props: {
+            striped: false,
+            size: 'md'
+          }
+        })
+
+        // @ts-expect-error: access internal computed since stripes doesn't render when false
+        const styles = wrapper.vm.stripeStyles
+
+        expect(styles.backgroundImage).toBeUndefined()
+      })
+
+      it('stripeStyles returns undefined for backgroundSize when striped is false and size is xs', () => {
+        const wrapper = mount(VkProgressbar, {
+          props: { striped: false, size: 'xs' }
+        })
+
+        // @ts-expect-error: access internal computed since stripes doesn't render when false
+        const styles = wrapper.vm.stripeStyles
+
+        expect(styles.backgroundSize).toBeUndefined()
+      })
     })
   })
 

--- a/packages/valko-ui-components/src/__test__/Radio.spec.ts
+++ b/packages/valko-ui-components/src/__test__/Radio.spec.ts
@@ -231,12 +231,36 @@ describe('Radio component', () => {
     })
   })
 
+  describe('Arias', () => {
+    it('should have aria-describedby when ariaDescribedBy prop is set', () => {
+      const wrapper = mount(VkRadio, {
+        props: {
+          ariaDescribedBy: 'radio-helpertext'
+        }
+      })
+
+      expect(wrapper.find('.vk-radio__radio-container').attributes('aria-describedby')).toBe('radio-helpertext')
+    })
+  })
+
   describe('Emits', () => {
     it('should emit update event', () => {
       const wrapper = mount(VkRadio, {})
 
       wrapper.find('.vk-radio__radio-container').trigger('click')
       expect(wrapper.emitted('update:modelValue'))
+    })
+
+    it('should not emit update event when disabled', async () => {
+      const wrapper = mount(VkRadio, {
+        props: {
+          disabled: true
+        }
+      })
+
+      await wrapper.find('.vk-radio__radio-container').trigger('click')
+
+      expect(wrapper.emitted('update:modelValue')).toBeUndefined()
     })
   })
 })

--- a/packages/valko-ui-components/src/__test__/Range.spec.ts
+++ b/packages/valko-ui-components/src/__test__/Range.spec.ts
@@ -1,5 +1,5 @@
 import { nextTick } from 'vue'
-import { VueWrapper, mount } from '@vue/test-utils'
+import { VueWrapper, mount, DOMWrapper } from '@vue/test-utils'
 import VkRange from '#valkoui/components/Range.vue'
 
 describe('Range component', () => {
@@ -359,6 +359,17 @@ describe('Range component', () => {
 
         expect(wrapper.emitted()['update:modelValue']![0]).toEqual([50])
       })
+
+      it('getNewThumbPosition returns 0 when sliderRef is null', () => {
+        const wrapper = mount(VkRange, {
+          props: { min: 0, max: 100, step: 5, modelValue: 0 }
+        })
+        // @ts-expect-error: direct access for test
+        wrapper.vm.sliderRef = null
+        // @ts-expect-error: direct access for test
+        const result = wrapper.vm.getNewThumbPosition(50)
+        expect(result).toBe(0)
+      })
     })
 
     describe('updateThumbPosition', () => {
@@ -463,6 +474,307 @@ describe('Range component', () => {
         expect(wrapper.emitted()['update:modelValue']![0]).toEqual([[50, 80]])
       })
     })
+
+    describe('handleKeyDown', () => {
+      it('should increment the value by step on ArrowRight key press', async () => {
+        wrapper = mount(VkRange, {
+          props: {
+            modelValue: 50,
+            step: 10
+          }
+        })
+
+        const thumb = wrapper.find('.vk-range__thumb')
+
+        await thumb.trigger('keydown', { key: 'ArrowRight' })
+        expect(wrapper.emitted()['update:modelValue']![0]).toEqual([60])
+      })
+
+      it('should decrement the value by step on ArrowLeft key press', async () => {
+        wrapper = mount(VkRange, {
+          props: {
+            modelValue: 50,
+            step: 10
+          }
+        })
+
+        const thumb = wrapper.find('.vk-range__thumb')
+
+        await thumb.trigger('keydown', { key: 'ArrowLeft' })
+        expect(wrapper.emitted()['update:modelValue']![0]).toEqual([40])
+      })
+
+      it('should increment the value by step on ArrowUp key press', async () => {
+        wrapper = mount(VkRange, {
+          props: {
+            modelValue: 50,
+            step: 10
+          }
+        })
+
+        const thumb = wrapper.find('.vk-range__thumb')
+
+        await thumb.trigger('keydown', { key: 'ArrowUp' })
+        expect(wrapper.emitted()['update:modelValue']![0]).toEqual([60])
+      })
+
+      it('should decrement the value by step on ArrowDown key press', async () => {
+        wrapper = mount(VkRange, {
+          props: {
+            modelValue: 50,
+            step: 10
+          }
+        })
+
+        const thumb = wrapper.find('.vk-range__thumb')
+
+        await thumb.trigger('keydown', { key: 'ArrowDown' })
+        expect(wrapper.emitted()['update:modelValue']![0]).toEqual([40])
+      })
+
+      it('should set the value to min on Home key press', async () => {
+        wrapper = mount(VkRange, {
+          props: {
+            modelValue: 50,
+            step: 10,
+            min: 0
+          }
+        })
+
+        const thumb = wrapper.find('.vk-range__thumb')
+
+        await thumb.trigger('keydown', { key: 'Home' })
+        expect(wrapper.emitted()['update:modelValue']![0]).toEqual([0])
+      })
+
+      it('should set the value to max on End key press', async () => {
+        wrapper = mount(VkRange, {
+          props: {
+            modelValue: 50,
+            step: 10,
+            max: 100
+          }
+        })
+
+        const thumb = wrapper.find('.vk-range__thumb')
+
+        await thumb.trigger('keydown', { key: 'End' })
+        expect(wrapper.emitted()['update:modelValue']![0]).toEqual([100])
+      })
+
+      it('should not change the value on unsupported key press', async () => {
+        wrapper = mount(VkRange, {
+          props: {
+            modelValue: 50,
+            step: 10
+          }
+        })
+
+        const thumb = wrapper.find('.vk-range__thumb')
+
+        await thumb.trigger('keydown', { key: 'A' })
+        expect(wrapper.emitted()['update:modelValue']).toBeUndefined()
+      })
+
+      it('should change the value by step on Arrow keys press when isDouble is true', async () => {
+        wrapper = mount(VkRange, {
+          props: {
+            modelValue: [30, 70],
+            step: 10,
+            isDouble: true
+          }
+        })
+
+        const thumbs = wrapper.findAll('.vk-range__thumb')
+        const firstThumb = thumbs[0]
+
+        await firstThumb.trigger('keydown', { key: 'ArrowRight' })
+        expect(wrapper.emitted()['update:modelValue']![0]).toEqual([[40, 70]])
+
+        await firstThumb.trigger('keydown', { key: 'ArrowLeft' })
+        expect(wrapper.emitted()['update:modelValue']![1]).toEqual([[30, 70]])
+      })
+    })
+
+    describe('onMove', () => {
+      it('should do nothing if isDragging is false', async () => {
+        wrapper = mount(VkRange, {
+          props: {
+            modelValue: 50
+          }
+        })
+
+        const vm = wrapper.vm as unknown as { isDragging: boolean; onMove: (event: MouseEvent) => void }
+
+        vm.isDragging = false
+
+        vm.onMove(new MouseEvent('mousemove', { clientX: 100 }))
+
+        expect(wrapper.emitted()['update:modelValue']).toBeUndefined()
+      })
+    })
+
+    describe('onSliderClick', () => {
+      it('should call handleMultipleThumbs when isDouble is true (else branch)', async () => {
+        const wrapper = mount(VkRange, {
+          props: {
+            modelValue: [10, 70],
+            isDouble: true,
+            min: 0,
+            max: 100,
+            step: 10
+          }
+        })
+
+        const slider = wrapper.find('.vk-range')
+        const sliderElement = slider.element as HTMLElement
+        sliderElement.getBoundingClientRect = () => ({
+          left: 0,
+          width: 100,
+          top: 0,
+          height: 10,
+          right: 100,
+          bottom: 10,
+          x: 0,
+          y: 0,
+          toJSON: () => {}
+        })
+
+        await slider.trigger('mousedown', { clientX: 20 })
+        await slider.trigger('mouseup')
+
+        expect(wrapper.emitted()['update:modelValue']![0]).toEqual([[20, 70]])
+      })
+
+      it('should use event.touches[0].clientX for touch events', async () => {
+        const wrapper = mount(VkRange, {
+          props: { modelValue: 30 }
+        })
+
+        const slider = wrapper.find('.vk-range')
+        const sliderElement = slider.element as HTMLElement
+        sliderElement.getBoundingClientRect = () => ({
+          left: 0,
+          width: 100,
+          top: 0,
+          height: 10,
+          right: 100,
+          bottom: 10,
+          x: 0,
+          y: 0,
+          toJSON: () => {}
+        })
+
+        const touch = {
+          touches: [{ clientX: 50 }]
+        }
+
+        // @ts-expect-error: direct access for test
+        wrapper.vm.onSliderClick(touch)
+        await wrapper.vm.$nextTick()
+
+        expect(wrapper.emitted()['update:modelValue'][0]).toEqual([50])
+      })
+    })
+
+    describe('onLabelClick', () => {
+      it('should use handleMultipleThumbs to move the closest thumb to the label value if double is true', async () => {
+        const labels = [{ value: 25, label: 'Low' }, { value: 75, label: 'High' }]
+        const wrapper = mount(VkRange, {
+          props: {
+            modelValue: [20, 80],
+            isDouble: true,
+            labels,
+            showSteps: false
+          }
+        })
+
+        const label = wrapper.find('.vk-range__label')
+
+        await label.trigger('click')
+
+        expect(wrapper.emitted()['update:modelValue']![0]).toEqual([[25, 80]])
+      })
+
+      it('should use handleSingleThumb to move the thumb to the label value if double is false', async () => {
+        const labels = [{ value: 25, label: 'Low' }, { value: 75, label: 'High' }]
+        const wrapper = mount(VkRange, {
+          props: {
+            modelValue: 20,
+            isDouble: false,
+            labels,
+            showSteps: false
+          }
+        })
+
+        const label = wrapper.find('.vk-range__label')
+
+        await label.trigger('click')
+
+        expect(wrapper.emitted()['update:modelValue']![0]).toEqual([25])
+      })
+    })
+
+    describe('onStart', () => {
+      it('should trigger on mousedown when double is true', async () => {
+        const wrapper = mount(VkRange, {
+          props: {
+            modelValue: [20, 80],
+            isDouble: true
+          }
+        })
+
+        const thumb = wrapper.find('.vk-range__thumb')
+
+        await thumb.trigger('mousedown', { clientX: 50 })
+
+        expect(wrapper.vm).toHaveProperty('isDragging', true)
+      })
+
+      it('should trigger on touchstart when double is true', async () => {
+        const wrapper = mount(VkRange, {
+          props: {
+            modelValue: [20, 80],
+            isDouble: true
+          }
+        })
+
+        const thumb = wrapper.find('.vk-range__thumb')
+        const touch = { touches: [{ clientX: 50 }] }
+        await thumb.trigger('touchstart', touch)
+        expect(wrapper.vm).toHaveProperty('isDragging', true)
+      })
+    })
+  })
+
+  describe('Watchers', () => {
+    it('updates thumbRefMap.min.value when min changes', async () => {
+      const wrapper = mount(VkRange, { props: { min: 0, max: 100, isDouble: false, step: 1, modelValue: 0 } })
+      await wrapper.setProps({ min: 10 })
+      // @ts-expect-error: direct access for test
+      expect(wrapper.vm.thumbRefMap.min.value).toBe(10)
+    })
+
+    it('updates thumbRefMap.max.value when max changes', async () => {
+      const wrapper = mount(VkRange, { props: { min: 0, max: 100, isDouble: false, step: 1, modelValue: 0 } })
+      await wrapper.setProps({ max: 90 })
+      // @ts-expect-error: direct access for test
+      expect(wrapper.vm.thumbRefMap.max.value).toBe(90)
+    })
+
+    it('emits [min, max] when isDouble is true', async () => {
+      const wrapper = mount(VkRange, { props: { min: 0, max: 100, isDouble: false, step: 1, modelValue: 0 } })
+      await wrapper.setProps({ isDouble: true, min: 5, max: 15 })
+      const lastEmission = wrapper.emitted()['update:modelValue'].pop()
+      expect(lastEmission).toEqual([[5, 15]])
+    })
+
+    it('emits max when isDouble is false', async () => {
+      const wrapper = mount(VkRange, { props: { min: 0, max: 100, isDouble: true, step: 1, modelValue: [0, 100] } })
+      await wrapper.setProps({ isDouble: false, max: 42 })
+      const lastEmission = wrapper.emitted()['update:modelValue'].pop()
+      expect(lastEmission).toEqual([42])
+    })
   })
 
   describe('Computed properties', () => {
@@ -563,6 +875,80 @@ describe('Range component', () => {
         const marks = (wrapper.vm as unknown as { stepMarks: number[] }).stepMarks
         expect(marks[0]).toBe(10)
       })
+    })
+  })
+
+  describe('Listeners', () => {
+    let wrapper: VueWrapper
+    let thumb: DOMWrapper<Element>
+    let touch: Touch
+    let moveTouch: Touch
+    let removeSpy: ReturnType<typeof vi.spyOn>
+
+    beforeEach(() => {
+      removeSpy = vi.spyOn(document, 'removeEventListener')
+      wrapper = mount(VkRange, {
+        props: {
+          modelValue: 0
+        }
+      })
+
+      thumb = wrapper.find('.vk-range__thumb')
+
+      touch = {
+        identifier: 0,
+        target: thumb.element,
+        clientX: 50,
+        clientY: 0,
+        screenX: 50,
+        screenY: 0,
+        pageX: 50,
+        pageY: 0,
+        radiusX: 0,
+        radiusY: 0,
+        rotationAngle: 0,
+        force: 0.5
+      }
+
+      moveTouch = {
+        ...touch,
+        clientX: 60,
+        pageX: 60,
+        screenX: 60
+      }
+    })
+
+    afterEach(() => {
+      removeSpy.mockRestore()
+      wrapper.unmount()
+    })
+
+    it('should remove mousemove listener after mouse interaction', async () => {
+      await thumb.trigger('mousedown', { clientX: 50 })
+      await document.dispatchEvent(new MouseEvent('mousemove', { clientX: 60 }))
+      await document.dispatchEvent(new MouseEvent('mouseup', { clientX: 60 }))
+      expect(removeSpy).toHaveBeenCalledWith('mousemove', expect.any(Function))
+    })
+
+    it('should remove touchmove listener after touch interaction', async () => {
+      await thumb.trigger('touchstart', { touches: [touch] })
+      await document.dispatchEvent(new TouchEvent('touchmove', { touches: [moveTouch] }))
+      await document.dispatchEvent(new TouchEvent('touchend', { changedTouches: [moveTouch] }))
+      expect(removeSpy).toHaveBeenCalledWith('touchmove', expect.any(Function))
+    })
+
+    it('should remove mouseup listener after mouse interaction', async () => {
+      await thumb.trigger('mousedown', { clientX: 50 })
+      await document.dispatchEvent(new MouseEvent('mousemove', { clientX: 60 }))
+      await document.dispatchEvent(new MouseEvent('mouseup', { clientX: 60 }))
+      expect(removeSpy).toHaveBeenCalledWith('mouseup', expect.any(Function))
+    })
+
+    it('should remove touchend listener after touch interaction', async () => {
+      await thumb.trigger('touchstart', { touches: [touch] })
+      await document.dispatchEvent(new TouchEvent('touchmove', { touches: [moveTouch] }))
+      await document.dispatchEvent(new TouchEvent('touchend', { changedTouches: [moveTouch] }))
+      expect(removeSpy).toHaveBeenCalledWith('touchend', expect.any(Function))
     })
   })
 

--- a/packages/valko-ui-components/src/__test__/Range.spec.ts
+++ b/packages/valko-ui-components/src/__test__/Range.spec.ts
@@ -364,9 +364,9 @@ describe('Range component', () => {
         const wrapper = mount(VkRange, {
           props: { min: 0, max: 100, step: 5, modelValue: 0 }
         })
-        // @ts-expect-error: direct access for test
+        // @ts-expect-error: forcing sliderRef to be null to test the fallback behavior
         wrapper.vm.sliderRef = null
-        // @ts-expect-error: direct access for test
+        // @ts-expect-error: forcing the call to getNewThumbPosition to test the fallback behavior when sliderRef is null
         const result = wrapper.vm.getNewThumbPosition(50)
         expect(result).toBe(0)
       })
@@ -669,7 +669,7 @@ describe('Range component', () => {
           touches: [{ clientX: 50 }]
         }
 
-        // @ts-expect-error: direct access for test
+        // @ts-expect-error: direct call to onSliderClick to simulate touch event
         wrapper.vm.onSliderClick(touch)
         await wrapper.vm.$nextTick()
 
@@ -751,14 +751,14 @@ describe('Range component', () => {
     it('updates thumbRefMap.min.value when min changes', async () => {
       const wrapper = mount(VkRange, { props: { min: 0, max: 100, isDouble: false, step: 1, modelValue: 0 } })
       await wrapper.setProps({ min: 10 })
-      // @ts-expect-error: direct access for test
+      // @ts-expect-error: accessing thumbRefMap for test purposes
       expect(wrapper.vm.thumbRefMap.min.value).toBe(10)
     })
 
     it('updates thumbRefMap.max.value when max changes', async () => {
       const wrapper = mount(VkRange, { props: { min: 0, max: 100, isDouble: false, step: 1, modelValue: 0 } })
       await wrapper.setProps({ max: 90 })
-      // @ts-expect-error: direct access for test
+      // @ts-expect-error: accessing thumbRefMap for test purposes
       expect(wrapper.vm.thumbRefMap.max.value).toBe(90)
     })
 

--- a/packages/valko-ui-components/src/__test__/Select.spec.ts
+++ b/packages/valko-ui-components/src/__test__/Select.spec.ts
@@ -302,11 +302,16 @@ describe('Select component', () => {
 
   describe('Methods', () => {
     describe('handleKeyDown', () => {
-      let wrapper: VueWrapper
       let input: DOMWrapper<HTMLInputElement>
+      let originalScrollIntoView: typeof window.HTMLElement.prototype.scrollIntoView
 
       beforeAll(() => {
+        originalScrollIntoView = window.HTMLElement.prototype.scrollIntoView
         window.HTMLElement.prototype.scrollIntoView = function () {}
+      })
+
+      afterAll(() => {
+        window.HTMLElement.prototype.scrollIntoView = originalScrollIntoView
       })
 
       beforeEach(async () => {

--- a/packages/valko-ui-components/src/__test__/Select.spec.ts
+++ b/packages/valko-ui-components/src/__test__/Select.spec.ts
@@ -678,13 +678,15 @@ describe('Select component', () => {
         const wrapper = mount(VkSelect, {
           props: {
             options,
+            multiple: true,
             attachTo: document.body
           }
         })
 
         await wrapper.find('.vk-input__input').trigger('focus')
         await wrapper.vm.$nextTick()
-        await wrapper.find('.vk-select__container').trigger('click')
+        const selectRefEl = wrapper.vm.$refs.selectRef as HTMLElement
+        selectRefEl.click()
         await wrapper.vm.$nextTick()
 
         expect(wrapper.find('.vk-select__dropdown').exists()).toBe(true)

--- a/packages/valko-ui-components/src/__test__/Select.spec.ts
+++ b/packages/valko-ui-components/src/__test__/Select.spec.ts
@@ -301,6 +301,115 @@ describe('Select component', () => {
   })
 
   describe('Methods', () => {
+    describe('handleKeyDown', () => {
+      let wrapper: VueWrapper
+      let input: DOMWrapper<HTMLInputElement>
+
+      beforeAll(() => {
+        window.HTMLElement.prototype.scrollIntoView = function () {}
+      })
+
+      beforeEach(async () => {
+        wrapper = mount(VkSelect, {
+          props: { options }
+        })
+
+        input = wrapper.find('.vk-input__input')
+        await input.trigger('focus')
+        await nextTick()
+      })
+
+      afterEach(() => wrapper.unmount())
+
+      it('should move highlight with ArrowDown', async () => {
+        await input.trigger('keydown', { key: 'ArrowDown' })
+        await nextTick()
+        const items = wrapper.findAll('.vk-select__item')
+
+        expect(items[0].attributes('data-highlighted')).toBe('true')
+      })
+
+      it('should move highlight with ArrowUp', async () => {
+        await input.trigger('keydown', { key: 'ArrowDown' })
+        await input.trigger('keydown', { key: 'ArrowDown' })
+        await nextTick()
+        await input.trigger('keydown', { key: 'ArrowUp' })
+        await nextTick()
+        const items = wrapper.findAll('.vk-select__item')
+
+        expect(items[0].attributes('data-highlighted')).toBe('true')
+      })
+
+      it('should move highlight to first with Home', async () => {
+        await input.trigger('keydown', { key: 'ArrowDown' })
+        await input.trigger('keydown', { key: 'ArrowDown' })
+        await nextTick()
+        await input.trigger('keydown', { key: 'Home' })
+        await nextTick()
+        const items = wrapper.findAll('.vk-select__item')
+
+        expect(items[0].attributes('data-highlighted')).toBe('true')
+      })
+
+      it('should move highlight to last with End', async () => {
+        await input.trigger('keydown', { key: 'End' })
+        await nextTick()
+        const items = wrapper.findAll('.vk-select__item')
+
+        expect(items[items.length - 1].attributes('data-highlighted')).toBe('true')
+      })
+
+      it('should select item with Enter if highlighted', async () => {
+        await input.trigger('keydown', { key: 'ArrowDown' })
+        await nextTick()
+        await input.trigger('keydown', { key: 'Enter' })
+
+        expect(wrapper.emitted('update:modelValue')).toBeDefined()
+      })
+
+      it('should select item with SpaceBar if highlighted', async () => {
+        await input.trigger('keydown', { key: 'ArrowDown' })
+        await input.trigger('keydown', { key: 'ArrowDown' })
+        await nextTick()
+        await input.trigger('keydown', { key: 'SpaceBar' })
+
+        expect(wrapper.emitted('update:modelValue')).toBeDefined()
+      })
+
+      it('should do nothing for unrelated keys', async () => {
+        await input.trigger('keydown', { key: 'Tab' })
+        await nextTick()
+
+        const items = wrapper.findAll('.vk-select__item')
+        const highlighted = items.filter(i => i.attributes('data-highlighted') === 'true')
+
+        expect(highlighted.length).toBe(0)
+      })
+
+      it('should select item with Enter if highlighted and multiple is true', async () => {
+        wrapper.setProps({ multiple: true })
+
+        await input.trigger('keydown', { key: 'ArrowDown' })
+        await nextTick()
+        await input.trigger('keydown', { key: 'Enter' })
+        await nextTick()
+
+        expect(wrapper.emitted('update:modelValue')?.[0][0]).toEqual([1])
+      })
+
+      it('should select item with SpaceBar if highlighted and multiple is true', async () => {
+        wrapper.setProps({ multiple: true })
+
+        await input.trigger('keydown', { key: 'ArrowDown' })
+        await input.trigger('keydown', { key: 'ArrowDown' })
+        await nextTick()
+        await input.trigger('keydown', { key: ' ' })
+        await nextTick()
+
+        expect(wrapper.emitted('update:modelValue')?.[0][0]).toEqual([2])
+      })
+    })
+
     describe('SelectItem functionality', () => {
       let items: DOMWrapper<HTMLElement>[]
 
@@ -474,6 +583,26 @@ describe('Select component', () => {
 
         expect(wrapper.find('.vk-select__dropdown').exists()).toBe(false)
       })
+
+      it('should close dropdown on blur', async () => {
+        await wrapper.find('.vk-input__input').trigger('blur')
+        await nextTick()
+        expect(wrapper.find('.vk-select__dropdown').exists()).toBe(false)
+      })
+
+      it('should close dropdown on Escape keydown', async () => {
+        await wrapper.find('.vk-input__input').trigger('keydown', { key: 'Escape' })
+        await nextTick()
+        expect(wrapper.find('.vk-select__dropdown').exists()).toBe(false)
+      })
+
+      it('should open dropdown when icon is clicked', async () => {
+        const icon = wrapper.findComponent({ name: 'VkIcon' })
+        await icon.trigger('click')
+        await nextTick()
+
+        expect(wrapper.find('.vk-select__dropdown').exists()).toBe(true)
+      })
     })
 
     describe('clearSelection', () => {
@@ -543,6 +672,22 @@ describe('Select component', () => {
         await wrapper.vm.$nextTick()
 
         expect(wrapper.find('.vk-select__dropdown').exists()).toBe(false)
+      })
+
+      it('should not close the dropdown when clicked inside', async () => {
+        const wrapper = mount(VkSelect, {
+          props: {
+            options,
+            attachTo: document.body
+          }
+        })
+
+        await wrapper.find('.vk-input__input').trigger('focus')
+        await wrapper.vm.$nextTick()
+        await wrapper.find('.vk-select__container').trigger('click')
+        await wrapper.vm.$nextTick()
+
+        expect(wrapper.find('.vk-select__dropdown').exists()).toBe(true)
       })
     })
 

--- a/packages/valko-ui-components/src/__test__/Switch.spec.ts
+++ b/packages/valko-ui-components/src/__test__/Switch.spec.ts
@@ -233,5 +233,17 @@ describe('Switch component', () => {
       wrapper.find('.cursor-pointer').trigger('click')
       expect(wrapper.emitted('update:modelValue'))
     })
+
+    it('should not emit update event when disabled', () => {
+      const wrapper = mount(VkSwitch, {
+        props: {
+          disabled: true
+        }
+      })
+
+      // @ts-expect-error: access internal since clicking the wrapper does not trigger the onClick method when disabled
+      wrapper.vm.onClick()
+      expect(wrapper.emitted('update:modelValue')).toBeUndefined()
+    })
   })
 })

--- a/packages/valko-ui-components/src/__test__/Table.spec.ts
+++ b/packages/valko-ui-components/src/__test__/Table.spec.ts
@@ -326,6 +326,80 @@ describe('Table component', () => {
 
         expect(wrapper.find('.vk-table__tr').classes()).toContain('even:bg-surface-container')
       })
+
+      it('should not be striped when false', () => {
+        const wrapper = mount(VkTable, {
+          props: {
+            headers,
+            data,
+            striped: false
+          }
+        })
+
+        expect(wrapper.find('.vk-table__tr').classes()).not.toContain('even:bg-surface-container')
+      })
+    })
+  })
+
+  describe('Arias', () => {
+    it('should set aria-selected single selection', () => {
+      const wrapper = mount(VkTable, {
+        props: {
+          headers,
+          data,
+          rowEvents: true,
+          selection: { key: 'headersKey' }
+        }
+      })
+
+      const row = wrapper.find('[data-key="headersKey"]')
+
+      expect(row.attributes('aria-selected')).toBe('true')
+    })
+
+    it('should set data-selected single selection', () => {
+      const wrapper = mount(VkTable, {
+        props: {
+          headers,
+          data,
+          rowEvents: true,
+          selection: { key: 'headersKey' }
+        }
+      })
+
+      const row = wrapper.find('[data-key="headersKey"]')
+
+      expect(row.attributes('data-selected')).toBe('true')
+    })
+
+    it('should set aria-selected for array selection', () => {
+      const wrapper = mount(VkTable, {
+        props: {
+          headers,
+          data,
+          rowEvents: true,
+          selection: [{ key: 'headersKey' }, { key: 'dataKey' }]
+        }
+      })
+
+      const row1 = wrapper.find('[data-key="headersKey"]')
+
+      expect(row1.attributes('aria-selected')).toBe('true')
+    })
+
+    it('should set data-selected for array selection', () => {
+      const wrapper = mount(VkTable, {
+        props: {
+          headers,
+          data,
+          rowEvents: true,
+          selection: [{ key: 'headersKey' }, { key: 'dataKey' }]
+        }
+      })
+
+      const row2 = wrapper.find('[data-key="dataKey"]')
+
+      expect(row2.attributes('data-selected')).toBe('true')
     })
   })
 
@@ -364,6 +438,17 @@ describe('Table component', () => {
       })
 
       expect(wrapper.find('.vk-table__no_data_message').text()).toBe('no data message')
+    })
+
+    it('should display the default message when no-data-message slot is not provided', () => {
+      wrapper = mount(VkTable, {
+        props: {
+          headers,
+          data: []
+        }
+      })
+
+      expect(wrapper.find('.vk-table__no_data_message').text()).toBe('No items found.')
     })
 
     it('should display the custom content in the table-footer slot', () => {
@@ -454,6 +539,25 @@ describe('Table component', () => {
       })
 
       expect(wrapper.find('.vk-table__no_data_message').text()).toBe('No items found.')
+    })
+
+    it('should use the index as key when item key is not provided', () => {
+      const dataWithoutKeys = data.map((item) => {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const { key, ...rest } = item
+        return rest
+      })
+
+      const wrapper = mount(VkTable, {
+        props: {
+          headers,
+          //@ts-expect-error: key is required in TableItem but we are testing the behavior when it's not provided
+          data: dataWithoutKeys
+        }
+      })
+
+      const items = wrapper.findAll('[data-key]')
+      expect(items[0].attributes('data-key')).toBe('0')
     })
   })
 

--- a/packages/valko-ui-components/src/__test__/Tabs.spec.ts
+++ b/packages/valko-ui-components/src/__test__/Tabs.spec.ts
@@ -10,6 +10,7 @@ describe('Tabs component', () => {
     { key: 'friends', title: 'Friends' }
   ]
   let wrapper: VueWrapper
+
   describe('Props', () => {
     describe('With default props', () => {
       beforeEach(async () => {

--- a/packages/valko-ui-components/src/__test__/Tabs.spec.ts
+++ b/packages/valko-ui-components/src/__test__/Tabs.spec.ts
@@ -251,6 +251,64 @@ describe('Tabs component', () => {
   })
 
   describe('Methods', () => {
+    describe('selectedIndex computed', () => {
+      it('should emit update:modelValue when modelValue is defined and tab changes', async () => {
+        const wrapper = mount(VkTabs, {
+          props: {
+            tabs,
+            modelValue: 0
+          }
+        })
+        const tabButtons = wrapper.findAll('[role="tab"]')
+        await tabButtons[1].trigger('click')
+
+        expect(wrapper.emitted('update:modelValue')).toBeDefined()
+      })
+    })
+
+    describe('moveCursor', () => {
+      it('should set cursorRef style.left with extraLeft when shape is line, variant is outlined, and vertical is true', async () => {
+        const wrapper = mount(VkTabs, {
+          props: {
+            tabs,
+            shape: 'line',
+            variant: 'outlined',
+            vertical: true
+          },
+          attachTo: document.body
+        })
+
+        await flushPromises()
+        const tabButtons = wrapper.findAll('[role="tab"]')
+        await tabButtons[1].trigger('click')
+        await flushPromises()
+        const cursorEl = wrapper.vm.$refs.cursorRef as HTMLElement
+        expect(cursorEl.style.left).not.toBe('')
+
+        wrapper.unmount()
+      })
+
+      it('should set cursorRef style properties when shape is line, variant is outlined, and vertical is false', async () => {
+        const wrapper = mount(VkTabs, {
+          props: {
+            tabs,
+            shape: 'line',
+            variant: 'outlined',
+            vertical: false
+          },
+          attachTo: document.body
+        })
+        await flushPromises()
+        const tabButtons = wrapper.findAll('[role="tab"]')
+        await tabButtons[1].trigger('click')
+        await flushPromises()
+        const cursorEl = wrapper.vm.$refs.cursorRef as HTMLElement
+        expect(cursorEl.style.width).not.toBe('')
+
+        wrapper.unmount()
+      })
+    })
+
     describe('onChange', () => {
       it('should not emit tabClick event if the tab is disabled', async () => {
         const wrapper = mount(VkTabs, {
@@ -262,10 +320,21 @@ describe('Tabs component', () => {
           }
         })
 
-        const tabList = wrapper.findComponent({ name: 'TabList' })
-        await tabList.find('button').trigger('click')
+        const tabButtons = wrapper.findAll('[role="tab"]')
+        await tabButtons[0].trigger('click')
 
         expect(wrapper.emitted('tabClick')).toBeUndefined()
+      })
+
+      it('should emit tabClick event with tab key when a tab is clicked', async () => {
+        const wrapper = mount(VkTabs, {
+          props: { tabs }
+        })
+
+        const tabButtons = wrapper.findAll('[role="tab"]')
+        await tabButtons[1].trigger('click')
+
+        expect(wrapper.emitted('tabClick')).toBeDefined()
       })
     })
   })

--- a/packages/valko-ui-components/src/__test__/Tag.spec.ts
+++ b/packages/valko-ui-components/src/__test__/Tag.spec.ts
@@ -372,5 +372,19 @@ describe('Tag component', () => {
       wrapper.find('.vk-tag').trigger('click')
       expect(wrapper.emitted()).toHaveProperty('click')
     })
+
+    it('should not emit close event when disabled', () => {
+      const wrapper = mount(VkTag, {
+        props: {
+          text: 'Hello World',
+          closable: true,
+          disabled: true
+        }
+      })
+
+      // @ts-expect-error: access the internal method since clicking the wrapper does not trigger the onClose method when disabled
+      wrapper.vm.onClose()
+      expect(wrapper.emitted()).not.toHaveProperty('close')
+    })
   })
 })

--- a/packages/valko-ui-components/src/__test__/Textarea.spec.ts
+++ b/packages/valko-ui-components/src/__test__/Textarea.spec.ts
@@ -245,6 +245,169 @@ describe('Textarea component', () => {
     })
   })
 
+  describe('Arias', () => {
+    it('should set aria-describedby when helpertext is present', () => {
+      wrapper = mount(VkTextarea, {
+        props: {
+          helpertext: 'Help text'
+        }
+      })
+      const helpertextId = wrapper.find('.vk-textarea__helper').attributes('id')
+      const describedby = wrapper.find('textarea').attributes('aria-describedby')
+      expect(describedby).toContain(helpertextId)
+    })
+
+    it('should set aria-describedby when ariaDescribedBy prop is present', () => {
+      wrapper = mount(VkTextarea, {
+        props: {
+          ariaDescribedBy: 'external-id'
+        }
+      })
+      expect(wrapper.find('textarea').attributes('aria-describedby')).toContain('external-id')
+    })
+
+    it('should set aria-describedby with both helpertext id and aria-describedby prop', () => {
+      wrapper = mount(VkTextarea, {
+        props: {
+          helpertext: 'Help text',
+          ariaDescribedBy: 'external-id'
+        }
+      })
+      const helpertextId = wrapper.find('.vk-textarea__helper').attributes('id')
+      const describedby = wrapper.find('textarea').attributes('aria-describedby')
+      expect(describedby).toContain(helpertextId)
+      expect(describedby).toContain('external-id')
+    })
+  })
+
+  describe('Methods', () => {
+    describe('updateValue', () => {
+      it('should update modelValue when input event is triggered', async () => {
+        wrapper = mount(VkTextarea, {
+          props: {
+            modelValue: ''
+          }
+        })
+
+        const textarea = wrapper.find('textarea')
+        await textarea.setValue('Hello World')
+        expect(wrapper.emitted()['update:modelValue'][0]).toEqual(['Hello World'])
+      })
+
+      it('should not emit update:modelValue when readonly is true', async () => {
+        wrapper = mount(VkTextarea, {
+          props: {
+            modelValue: '',
+            readonly: true
+          }
+        })
+
+        const textarea = wrapper.find('textarea')
+        await textarea.setValue('Hello World')
+        expect(wrapper.emitted()['update:modelValue']).toBeUndefined()
+      })
+
+      it('should not emit update:modelValue when disabled is true', async () => {
+        wrapper = mount(VkTextarea, {
+          props: {
+            modelValue: '',
+            disabled: true
+          }
+        })
+
+        const textarea = wrapper.find('textarea')
+        await textarea.setValue('Hello World')
+        expect(wrapper.emitted()['update:modelValue']).toBeUndefined()
+      })
+    })
+
+    describe('handleIconClick', () => {
+      it('should emit leftIconClick event when the left icon is clicked', async () => {
+        wrapper = mount(VkTextarea, {
+          slots: {
+            'left-icon': '<span>Left Icon</span>'
+          }
+        })
+
+        const icon = wrapper.find('.vk-textarea__left-icon')
+        await icon.trigger('click')
+        expect(wrapper.emitted()).toHaveProperty('leftIconClick')
+      })
+
+      it('should not emit leftIconClick event when the textarea is disabled', async () => {
+        wrapper = mount(VkTextarea, {
+          props: {
+            disabled: true
+          },
+          slots: {
+            'left-icon': '<span>Left Icon</span>'
+          }
+        })
+
+        const icon = wrapper.find('.vk-textarea__left-icon')
+        await icon.trigger('click')
+        expect(wrapper.emitted()).not.toHaveProperty('leftIconClick')
+      })
+
+      it('should not emit leftIconClick event when the textarea is readonly', async () => {
+        wrapper = mount(VkTextarea, {
+          props: {
+            readonly: true
+          },
+          slots: {
+            'left-icon': '<span>Left Icon</span>'
+          }
+        })
+
+        const icon = wrapper.find('.vk-textarea__left-icon')
+        await icon.trigger('click')
+        expect(wrapper.emitted()).not.toHaveProperty('leftIconClick')
+      })
+
+      it('should emit rightIconClick event when the right icon is clicked', async () => {
+        wrapper = mount(VkTextarea, {
+          slots: {
+            'right-icon': '<span>Right Icon</span>'
+          }
+        })
+
+        const icon = wrapper.find('.vk-textarea__right-icon')
+        await icon.trigger('click')
+        expect(wrapper.emitted()).toHaveProperty('rightIconClick')
+      })
+
+      it('should not emit rightIconClick event when the textarea is disabled', async () => {
+        wrapper = mount(VkTextarea, {
+          props: {
+            disabled: true
+          },
+          slots: {
+            'right-icon': '<span>Right Icon</span>'
+          }
+        })
+
+        const icon = wrapper.find('.vk-textarea__right-icon')
+        await icon.trigger('click')
+        expect(wrapper.emitted()).not.toHaveProperty('rightIconClick')
+      })
+
+      it('should not emit rightIconClick event when the textarea is readonly', async () => {
+        wrapper = mount(VkTextarea, {
+          props: {
+            readonly: true
+          },
+          slots: {
+            'right-icon': '<span>Right Icon</span>'
+          }
+        })
+
+        const icon = wrapper.find('.vk-textarea__right-icon')
+        await icon.trigger('click')
+        expect(wrapper.emitted()).not.toHaveProperty('rightIconClick')
+      })
+    })
+  })
+
   describe('Emits', () => {
     it('should emit focus event', () => {
       const wrapper = mount(VkTextarea, {})

--- a/packages/valko-ui-components/src/__test__/Time.spec.ts
+++ b/packages/valko-ui-components/src/__test__/Time.spec.ts
@@ -412,13 +412,10 @@ describe('Time component', () => {
         }
       })
 
-      const hourContainers = wrapper.findAll('.vk-time__unitContainer')
-      const hourBtn = hourContainers[0]?.findAll('.vk-time__unit-button')[1]
+      const unitContainer = wrapper.findAll('.vk-time__unit-container').at(0)
+      await unitContainer?.findAll('.vk-time__unit-button').at(1)?.trigger('click')
 
-      if (hourBtn) {
-        await hourBtn.trigger('click')
-        expect(adapter.setDisplayUnit).toHaveBeenCalledWith('h', '01')
-      }
+      expect(adapter.setDisplayUnit).toHaveBeenCalledWith('h', 1)
     })
 
     it('should call setDisplayUnit for minute button', async () => {
@@ -429,13 +426,10 @@ describe('Time component', () => {
         }
       })
 
-      const unitContainers = wrapper.findAll('.vk-time__unitContainer')
-      const minuteBtn = unitContainers[1]?.findAll('.vk-time__unit-button')[2]
+      const unitContainer = wrapper.findAll('.vk-time__unit-container').at(1)
+      await unitContainer?.findAll('.vk-time__unit-button').at(2)?.trigger('click')
 
-      if (minuteBtn) {
-        await minuteBtn.trigger('click')
-        expect(adapter.setDisplayUnit).toHaveBeenCalledWith('m', '02')
-      }
+      expect(adapter.setDisplayUnit).toHaveBeenCalledWith('m', 2)
     })
 
     it('should call setDisplayUnit for second button', async () => {
@@ -446,13 +440,10 @@ describe('Time component', () => {
         }
       })
 
-      const unitContainers = wrapper.findAll('.vk-time__unitContainer')
-      const secondBtn = unitContainers[2]?.findAll('.vk-time__unit-button')[3]
+      const unitContainer = wrapper.findAll('.vk-time__unit-container').at(2)
+      await unitContainer?.findAll('.vk-time__unit-button').at(3)?.trigger('click')
 
-      if (secondBtn) {
-        await secondBtn.trigger('click')
-        expect(adapter.setDisplayUnit).toHaveBeenCalledWith('s', '03')
-      }
+      expect(adapter.setDisplayUnit).toHaveBeenCalledWith('s', 3)
     })
   })
 

--- a/packages/valko-ui-components/src/__test__/Time.spec.ts
+++ b/packages/valko-ui-components/src/__test__/Time.spec.ts
@@ -1,5 +1,5 @@
 import { ref, computed, toValue } from 'vue'
-import { VueWrapper, mount } from '@vue/test-utils'
+import { DOMWrapper, VueWrapper, mount } from '@vue/test-utils'
 import VkTime from '#valkoui/components/Time.vue'
 import type { TimeAdapterResult } from '#valkoui/types/Time'
 
@@ -270,6 +270,300 @@ describe('Time component', () => {
         })
 
         expect(wrapper.find('.vk-time__ok-button').classes()).toContain('bg-primary-container')
+      })
+    })
+  })
+
+  describe('Methods', () => {
+    describe('formatMap', () => {
+      it('should render 12 hour buttons when format is 12-hour', () => {
+        const wrapper = mount(VkTime, {
+          props: {
+            modelValue,
+            adapter,
+            format: 'hh:mm:ss'
+          }
+        })
+
+        expect(wrapper.findAll('.vk-time__unit-button').length).toBeGreaterThanOrEqual(12)
+      })
+
+      it('should render 24 hour buttons when format is 24-hour', () => {
+        const wrapper = mount(VkTime, {
+          props: {
+            modelValue,
+            adapter,
+            format: 'HH:mm:ss'
+          }
+        })
+
+        expect(wrapper.findAll('.vk-time__unit-button').length).toBeGreaterThanOrEqual(24)
+      })
+    })
+
+    describe('selectedTime', () => {
+      describe('Using display values', () => {
+        let buttons: DOMWrapper<Element>[]
+
+        beforeEach(() => {
+          const wrapper = mount(VkTime, {
+            props: {
+              modelValue,
+              adapter,
+              format: 'HH:mm:ss'
+            }
+          })
+
+          buttons = wrapper.findAll('.vk-time__unit-button')
+        })
+
+        it('should highlight hour matching display values', () => {
+          // hours: index 0-23
+          const hourBtn = buttons[10]
+          expect(hourBtn?.classes()).toContain('bg-primary')
+        })
+
+        it('should highlight minute matching display values', () => {
+          // minutes: index 24-83
+          const minuteBtn = buttons[24 + 10]
+          expect(minuteBtn?.classes()).toContain('bg-primary')
+        })
+
+        it('should highlight second matching display values', () => {
+          // seconds: index 84-143
+          const secondBtn = buttons[84 + 10]
+          expect(secondBtn?.classes()).toContain('bg-primary')
+        })
+      })
+
+      describe('Fallback to selected values', () => {
+        let buttons: DOMWrapper<Element>[]
+        beforeEach(() => {
+
+          const mockAdapter = {
+            ...adapter,
+            formattedTime: computed(() => ({
+              selected: { hours: 1, minutes: 2, seconds: 3, obj: new Date() }
+              // display intentionally omitted
+            }))
+          }
+          const wrapper = mount(VkTime, {
+            props: {
+              modelValue,
+              // @ts-expect-error: Intentionally omitting display to test fallback to selected in selectedTime
+              adapter: mockAdapter
+            }
+          })
+
+          buttons = wrapper.findAll('.vk-time__unit-button')
+        })
+
+        it('should highlight hour matching selected value', () => {
+          expect(buttons[1]?.classes()).toContain('bg-primary')
+        })
+
+        it('should highlight minute matching selected value', () => {
+          expect(buttons[24 + 2]?.classes()).toContain('bg-primary')
+        })
+
+        it('should highlight second matching selected value', () => {
+          expect(buttons[84 + 3]?.classes()).toContain('bg-primary')
+        })
+      })
+    })
+
+    describe('formatHour', () => {
+      it('should render 12 for hour 0 in 12-hour format', () => {
+        const wrapper = mount(VkTime, {
+          props: {
+            modelValue,
+            adapter,
+            format: 'hh:mm:ss'
+          }
+        })
+
+        const hourBtn = wrapper.findAll('.vk-time__unit-button').find(btn => btn.text() === '12')
+
+        expect(hourBtn).toBeTruthy()
+      })
+
+      it('should render 0 for hour 0 in 24-hour format', () => {
+        const wrapper = mount(VkTime, {
+          props: {
+            modelValue,
+            adapter,
+            format: 'HH:mm:ss'
+          }
+        })
+
+        const hourBtn = wrapper.findAll('.vk-time__unit-button').find(btn => btn.text() === '00')
+
+        expect(hourBtn).toBeTruthy()
+      })
+    })
+  })
+
+  describe('Adapter methods', () => {
+    it('should call setDisplayUnit for hour button', async () => {
+      const wrapper = mount(VkTime, {
+        props: {
+          modelValue,
+          adapter
+        }
+      })
+
+      const hourContainers = wrapper.findAll('.vk-time__unitContainer')
+      const hourBtn = hourContainers[0]?.findAll('.vk-time__unit-button')[1]
+
+      if (hourBtn) {
+        await hourBtn.trigger('click')
+        expect(adapter.setDisplayUnit).toHaveBeenCalledWith('h', '01')
+      }
+    })
+
+    it('should call setDisplayUnit for minute button', async () => {
+      const wrapper = mount(VkTime, {
+        props: {
+          modelValue,
+          adapter
+        }
+      })
+
+      const unitContainers = wrapper.findAll('.vk-time__unitContainer')
+      const minuteBtn = unitContainers[1]?.findAll('.vk-time__unit-button')[2]
+
+      if (minuteBtn) {
+        await minuteBtn.trigger('click')
+        expect(adapter.setDisplayUnit).toHaveBeenCalledWith('m', '02')
+      }
+    })
+
+    it('should call setDisplayUnit for second button', async () => {
+      const wrapper = mount(VkTime, {
+        props: {
+          modelValue,
+          adapter
+        }
+      })
+
+      const unitContainers = wrapper.findAll('.vk-time__unitContainer')
+      const secondBtn = unitContainers[2]?.findAll('.vk-time__unit-button')[3]
+
+      if (secondBtn) {
+        await secondBtn.trigger('click')
+        expect(adapter.setDisplayUnit).toHaveBeenCalledWith('s', '03')
+      }
+    })
+  })
+
+  describe('Period buttons', () => {
+    describe('when period is AM', () => {
+      let wrapper: VueWrapper
+      let amBtn: DOMWrapper<Element> | undefined
+      let pmBtn: DOMWrapper<Element> | undefined
+
+      beforeEach(() => {
+        const amAdapter = {
+          ...adapter,
+          period: ref<'AM' | 'PM'>('AM'),
+          formattedTime: computed(() => ({
+            selected: { hours: 8, minutes: 0, seconds: 0, obj: new Date(1728950400 * 1000) },
+            display: { hours: 8, minutes: 0, seconds: 0, obj: new Date(1728950400 * 1000) }
+          }))
+        }
+
+        wrapper = mount(VkTime, {
+          props: {
+            modelValue,
+            adapter: amAdapter,
+            format: 'HH:mm:ss A'
+          }
+        })
+
+        const periodBtns = wrapper.findAll('button').filter(btn => btn.text() === 'AM' || btn.text() === 'PM')
+        amBtn = periodBtns.find(btn => btn.text() === 'AM')
+        pmBtn = periodBtns.find(btn => btn.text() === 'PM')
+      })
+
+      it('should render AM as selected', () => {
+        expect(amBtn?.classes()).toContain('bg-primary')
+      })
+
+      it('should render PM as unselected', () => {
+        expect(pmBtn?.classes()).toContain('text-on-surface')
+      })
+    })
+
+    describe('when period is PM', () => {
+      let wrapper: VueWrapper
+      let amBtn: DOMWrapper<Element> | undefined
+      let pmBtn: DOMWrapper<Element> | undefined
+
+      beforeEach(() => {
+        const pmAdapter = {
+          ...adapter,
+          period: ref<'AM' | 'PM'>('PM'),
+          formattedTime: computed(() => ({
+            selected: { hours: 15, minutes: 0, seconds: 0, obj: new Date(1728990000 * 1000) },
+            display: { hours: 15, minutes: 0, seconds: 0, obj: new Date(1728990000 * 1000) }
+          }))
+        }
+
+        wrapper = mount(VkTime, {
+          props: {
+            modelValue,
+            adapter: pmAdapter,
+            format: 'HH:mm:ss A'
+          }
+        })
+
+        const periodBtns = wrapper.findAll('button').filter(btn => btn.text() === 'AM' || btn.text() === 'PM')
+        amBtn = periodBtns.find(btn => btn.text() === 'AM')
+        pmBtn = periodBtns.find(btn => btn.text() === 'PM')
+      })
+
+      it('should render PM as selected', () => {
+        expect(pmBtn?.classes()).toContain('bg-primary')
+      })
+
+      it('should render AM as unselected', () => {
+        expect(amBtn?.classes()).toContain('text-on-surface')
+      })
+    })
+
+    describe('onSelectAMPM', () => {
+      it('should call onSelectAMPM when clicking AM button', async () => {
+        const wrapper = mount(VkTime, {
+          props: {
+            modelValue,
+            adapter,
+            format: 'hh:mm:ss A'
+          }
+        })
+
+        const amBtn = wrapper.findAll('button').find(btn => btn.text() === 'AM')
+
+        if (amBtn) {
+          await amBtn.trigger('click')
+          expect(adapter.onSelectAMPM).toHaveBeenCalledWith('AM')
+        }
+      })
+
+      it('should call onSelectAMPM when clicking PM button', async () => {
+        const wrapper = mount(VkTime, {
+          props: {
+            modelValue,
+            adapter,
+            format: 'hh:mm:ss A'
+          }
+        })
+
+        const pmBtn = wrapper.findAll('button').find(btn => btn.text() === 'PM')
+
+        if (pmBtn) {
+          await pmBtn.trigger('click')
+          expect(adapter.onSelectAMPM).toHaveBeenCalledWith('PM')
+        }
       })
     })
   })

--- a/packages/valko-ui-components/src/__test__/Time.spec.ts
+++ b/packages/valko-ui-components/src/__test__/Time.spec.ts
@@ -318,19 +318,16 @@ describe('Time component', () => {
         })
 
         it('should highlight hour matching display values', () => {
-          // hours: index 0-23
           const hourBtn = buttons[10]
           expect(hourBtn?.classes()).toContain('bg-primary')
         })
 
         it('should highlight minute matching display values', () => {
-          // minutes: index 24-83
           const minuteBtn = buttons[24 + 10]
           expect(minuteBtn?.classes()).toContain('bg-primary')
         })
 
         it('should highlight second matching display values', () => {
-          // seconds: index 84-143
           const secondBtn = buttons[84 + 10]
           expect(secondBtn?.classes()).toContain('bg-primary')
         })
@@ -344,7 +341,6 @@ describe('Time component', () => {
             ...adapter,
             formattedTime: computed(() => ({
               selected: { hours: 1, minutes: 2, seconds: 3, obj: new Date() }
-              // display intentionally omitted
             }))
           }
           const wrapper = mount(VkTime, {

--- a/packages/valko-ui-components/src/__test__/Timepicker.spec.ts
+++ b/packages/valko-ui-components/src/__test__/Timepicker.spec.ts
@@ -313,6 +313,24 @@ describe('Time component', () => {
     })
   })
 
+  describe('Listeners', () => {
+    it('should remove event listeners when the component is unmounted', async () => {
+      const removeSpy = vi.spyOn(document, 'removeEventListener')
+      const wrapper = mount(VkTimepicker, {
+        props: {
+          isOpen: true,
+          modelValue,
+          parsedModel,
+          adapter
+        }
+      })
+
+      wrapper.unmount()
+      expect(removeSpy).toHaveBeenCalledWith('mousedown', expect.any(Function), true)
+      removeSpy.mockRestore()
+    })
+  })
+
   describe('Emits', () => {
     it('should emit open event', async () => {
       const wrapper = mount(VkTimepicker, {

--- a/packages/valko-ui-components/src/__test__/useClientSideDragAndDrop.spec.ts
+++ b/packages/valko-ui-components/src/__test__/useClientSideDragAndDrop.spec.ts
@@ -36,4 +36,15 @@ describe('useClientSideDragAndDrop composable', () => {
       { key: 'item1', name: 'John', age: 30 }
     ])
   })
+
+  it('should do nothing if dragStartIndex or draggedItem is null', async () => {
+    const { result, handleDrop } = useClientSideDragAndDrop(data)
+    const mockDragEvent = createMockDragEvent()
+
+    const original = [...result.value]
+    handleDrop(mockDragEvent, 1)
+    await nextTick()
+
+    expect(result.value).toEqual(original)
+  })
 })

--- a/packages/valko-ui-components/src/__test__/useClientSidePagination.spec.ts
+++ b/packages/valko-ui-components/src/__test__/useClientSidePagination.spec.ts
@@ -10,6 +10,22 @@ describe('useClientSidePagination composable', () => {
     { id: 5, name: 'Eve' }
   ]
 
+  it('should use default limit of 10 when not provided', () => {
+    const { result } = useClientSidePagination(data)
+    expect(result.value).toEqual({
+      records: [
+        { id: 1, name: 'Alice' },
+        { id: 2, name: 'Bob' },
+        { id: 3, name: 'Charlie' },
+        { id: 4, name: 'David' },
+        { id: 5, name: 'Eve' }
+      ],
+      total: 5,
+      limit: 10,
+      offset: 0
+    })
+  })
+
   it('should initialize with the correct default pagination', () => {
     const { result } = useClientSidePagination(data, 2)
     expect(result.value).toEqual({

--- a/packages/valko-ui-components/src/__test__/useDataTable.spec.ts
+++ b/packages/valko-ui-components/src/__test__/useDataTable.spec.ts
@@ -67,6 +67,16 @@ describe('useDataTable composable', () => {
   })
 
   describe('When selectionMode changes', () => {
+    it('should use none as default selectionMode', () => {
+      const dataTable = useDataTable({
+        headers,
+        paginatedResult,
+        selectAllStatus: undefined,
+        draggable: false
+      })
+
+      expect(dataTable.value.headers).toEqual(headers)
+    })
     it('should return headers without changes when selectionMode is none', () => {
       const dataTable = useDataTable({
         headers,
@@ -118,6 +128,17 @@ describe('useDataTable composable', () => {
   })
 
   describe('When draggable changes', () => {
+    it('should use false as default draggable', () => {
+      const dataTable = useDataTable({
+        headers,
+        paginatedResult,
+        selectAllStatus: undefined,
+        selectionMode: 'none'
+      })
+
+      expect(dataTable.value.headers).toEqual(headers)
+    })
+
     it('should return headers without changes if draggable is false', () => {
       const dataTable = useDataTable({
         headers,
@@ -229,6 +250,26 @@ describe('useDataTable composable', () => {
 
       expect(dataTable.value.selection).toEqual([paginatedResult.value.records[0], paginatedResult.value.records[1]])
     })
+
+    it('should remove item from selection when it is already selected in multiple selection modes', async () => {
+      const dataTable = useDataTable({
+        headers,
+        paginatedResult,
+        selectAllStatus: undefined,
+        selectionMode: 'multiple',
+        draggable: false
+      })
+
+      if (dataTable.value.onSelect) {
+        dataTable.value.onSelect(paginatedResult.value.records[0])
+        dataTable.value.onSelect(paginatedResult.value.records[1])
+        dataTable.value.onSelect(paginatedResult.value.records[0])
+      }
+
+      await nextTick()
+
+      expect(dataTable.value.selection).toEqual([paginatedResult.value.records[1]])
+    })
   })
 
   describe('When selectAllStatus changes', () => {
@@ -266,6 +307,27 @@ describe('useDataTable composable', () => {
       })
 
       expect(dataTable.value.isAllSelected).toEqual(true)
+    })
+
+    it('should return false when select all is called and data is empty', () => {
+      const paginatedResultLocal = ref({
+        records: [],
+        limit: 10,
+        offset: 0,
+        total: 0
+      })
+
+      const dataTable = useDataTable({
+        headers,
+        paginatedResult: paginatedResultLocal,
+        selectAllStatus: undefined,
+        selectionMode: 'multiple',
+        draggable: false
+      })
+
+      if (dataTable.value.onSelectAll) dataTable.value.onSelectAll(true)
+
+      expect(dataTable.value.isAllSelected).toEqual(false)
     })
   })
 

--- a/packages/valko-ui-components/src/__test__/useDateAdapter.spec.ts
+++ b/packages/valko-ui-components/src/__test__/useDateAdapter.spec.ts
@@ -1,4 +1,5 @@
 import useDateAdapter from '#valkoui/composables/useDateAdapter'
+import type { CalendarAdapter } from '#valkoui/types/Calendar'
 
 describe('useDateAdapter composable', () => {
   const mockDate = new Date(2024, 9, 18)
@@ -11,14 +12,26 @@ describe('useDateAdapter composable', () => {
     vi.useRealTimers()
   })
 
-  describe('Model prop', () => {
+  describe('model', () => {
     it('should return model as an EpochTimeStamp', () => {
-      const [model] = useDateAdapter({ format: 'YYYY-MM-DD' })
+      const [ model ] = useDateAdapter({ format: 'YYYY-MM-DD' })
       expect(model.value).toBe(new Date(2024, 9, 18).getTime())
     })
   })
 
-  describe('ParsedModel prop', () => {
+  describe('parsedModel', () => {
+    it('should fallback to default format YYYY-MM-DD if format is missing', () => {
+      const [, parsedModel] = useDateAdapter({})
+      const today = new Date()
+      const expected = [
+        today.getFullYear(),
+        String(today.getMonth() + 1).padStart(2, '0'),
+        String(today.getDate()).padStart(2, '0')
+      ].join('-')
+
+      expect(parsedModel.value).toBe(expected)
+    })
+
     it('should format the year as YYYY (full year)', () => {
       const [, parsedModel] = useDateAdapter({ format: 'YYYY' })
       const currentYear = new Date().getFullYear()
@@ -86,68 +99,137 @@ describe('useDateAdapter composable', () => {
     })
   })
 
-  describe('Date interaction and helper functions', () => {
-    describe('GetWeekdays', () => {
-      it('should return correct weekdays based on locale', () => {
-        const [, , adapter] = useDateAdapter({ locale: 'en-US', format: 'YYYY-MM-DD' })
-        const weekdays = adapter.getWeekdays()
-
-        expect(weekdays).toEqual(['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'])
-      })
+  describe('formattedDates', () => {
+    it('should fallback to today for day if model is falsy', () => {
+      const [model, , adapter] = useDateAdapter({})
+      model.value = 0
+      const today = new Date()
+      expect(adapter.formattedDates.value.selected.day).toBe(today.getDate())
     })
-
-    describe('GetMonths', () => {
-      it('should return correct months based on locale', () => {
-        const [, , adapter] = useDateAdapter({ locale: 'en-US', format: 'YYYY-MM-DD' })
-        const months = adapter.getMonths()
-
-        expect(months).toEqual([
-          'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'
-        ])
-      })
+    it('should fallback to today for month if model is falsy', () => {
+      const [model, , adapter] = useDateAdapter({})
+      model.value = 0
+      const today = new Date()
+      expect(adapter.formattedDates.value.selected.month).toBe(today.getMonth())
     })
-
-    describe('onSelectDay', () => {
-      it('should correctly select a day using onSelectDay', () => {
-        const selectedDay = 18
-        const [, , adapter] = useDateAdapter({
-          format: 'DD'
-        })
-
-        adapter.onSelectDay(selectedDay)
-
-        expect(adapter.formattedDates.value.selected.day).toBe(selectedDay)
-      })
-    })
-
-    describe('onSelectMonth', () => {
-      it('should correctly select a month using onSelectMonth', () => {
-        const selectedMonth = 9
-        const [, , adapter] = useDateAdapter({
-          format: 'MM'
-        })
-
-        adapter.onSelectMonth(selectedMonth)
-
-        expect(adapter.formattedDates.value.selected.month).toBe(selectedMonth)
-      })
-    })
-
-    describe('onSelectYear', () => {
-      it('should correctly select a year using onSelectYear', () => {
-        const selectedYear = 2024
-        const [, , adapter] = useDateAdapter({
-          format: 'YYYY'
-        })
-
-        adapter.onSelectYear(selectedYear)
-
-        expect(adapter.formattedDates.value.selected.year).toBe(selectedYear)
-      })
+    it('should fallback to today for year if model is falsy', () => {
+      const [model, , adapter] = useDateAdapter({})
+      model.value = 0
+      const today = new Date()
+      expect(adapter.formattedDates.value.selected.year).toBe(today.getFullYear())
     })
   })
 
-  describe('When DisabledDates funcionality is added or not', () => {
+  describe('getWeekdays', () => {
+    it('should return correct weekdays based on locale', () => {
+      const [, , adapter] = useDateAdapter({ locale: 'en-US', format: 'YYYY-MM-DD' })
+      const weekdays = adapter.getWeekdays()
+      expect(weekdays).toEqual(['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'])
+    })
+  })
+
+  describe('getMonths', () => {
+    it('should return correct months based on locale', () => {
+      const [, , adapter] = useDateAdapter({ locale: 'en-US', format: 'YYYY-MM-DD' })
+      const months = adapter.getMonths()
+      expect(months).toEqual([
+        'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'
+      ])
+    })
+  })
+
+  describe('onSelectDay', () => {
+    describe('with YYYY-MM-DD format and known model', () => {
+      let model
+      let adapter: CalendarAdapter
+
+      beforeEach(() => {
+        [model, , adapter] = useDateAdapter({ format: 'YYYY-MM-DD' })
+        model.value = new Date(2022, 5, 1).getTime()
+      })
+
+      it('should set the selected day from tempDate', () => {
+        adapter.onSelectYear(2022)
+        adapter.onSelectMonth(5)
+        adapter.onSelectDay(10)
+        expect(adapter.formattedDates.value.display.day).toBe(10)
+      })
+
+      it('should set the selected month from tempDate', () => {
+        adapter.onSelectYear(2022)
+        adapter.onSelectMonth(5)
+        adapter.onSelectDay(10)
+        expect(adapter.formattedDates.value.display.month).toBe(5)
+      })
+
+      it('should set the selected year from tempDate', () => {
+        adapter.onSelectYear(2022)
+        adapter.onSelectMonth(5)
+        adapter.onSelectDay(10)
+        expect(adapter.formattedDates.value.display.year).toBe(2022)
+      })
+    })
+
+    it('should set year to default when format is MM-DD', () => {
+      const mockYear = new Date().getFullYear()
+      const [model, , adapter] = useDateAdapter({ format: 'MM-DD' })
+      model.value = new Date(mockYear, 5, 1).getTime()
+      adapter.onSelectMonth(5)
+      adapter.onSelectDay(10)
+      expect(adapter.formattedDates.value.display.year).toBe(mockYear)
+    })
+
+    it('should use the actual year if format is DD and tempDate is not set', () => {
+      const [, , adapter] = useDateAdapter({ format: 'DD' })
+      adapter.onSelectDay(15)
+      expect(adapter.formattedDates.value.display.year).toBe(new Date().getFullYear())
+    })
+  })
+
+  describe('onSelectMonth', () => {
+    describe('with YYYY-MM format and known model', () => {
+      let model
+      let adapter: CalendarAdapter
+
+      beforeEach(() => {
+        [model, , adapter] = useDateAdapter({ format: 'YYYY-MM' })
+        model.value = new Date(2022, 7, 1).getTime()
+      })
+
+      it('should set the selected year from tempDate', () => {
+        adapter.onSelectYear(2022)
+        adapter.onSelectMonth(7)
+        expect(adapter.formattedDates.value.display.year).toBe(2022)
+      })
+
+      it('should set the selected month from tempDate', () => {
+        adapter.onSelectYear(2022)
+        adapter.onSelectMonth(7)
+        expect(adapter.formattedDates.value.display.month).toBe(7)
+      })
+
+      it('should set the year after selecting year and month', () => {
+        adapter.onSelectYear(2022)
+        adapter.onSelectMonth(7)
+        expect(adapter.formattedDates.value.display.year).toBe(2022)
+      })
+    })
+
+    it('should set year to default when format is MM', () => {
+      const mockYear = new Date().getFullYear()
+      const [model, , adapter] = useDateAdapter({ format: 'MM' })
+      model.value = new Date(mockYear, 7, 1).getTime()
+      adapter.onSelectMonth(7)
+      expect(adapter.formattedDates.value.display.year).toBe(mockYear)
+    })
+  })
+
+  describe('disabledDates', () => {
+    it('should return an empty array if disabledDates is not provided', () => {
+      const [, , adapter] = useDateAdapter({ format: 'YYYY-MM-DD' })
+      expect(adapter.disabledDates.value).toEqual([])
+    })
+
     it('should return the correct disabled date for a single day', () => {
       const disabledTimestamp = new Date(2024, 9, 17).getTime()
       const [, , adapter] = useDateAdapter({
@@ -211,7 +293,7 @@ describe('useDateAdapter composable', () => {
 
   describe('When min & max date funcionality is added or not', () => {
     it('should correctly format minDate in formattedDates', () => {
-      const minDate = new Date(2024, 0, 1) // 1 de enero de 2024
+      const minDate = new Date(2024, 0, 1)
       const minTimestamp = minDate.getTime()
       const [, , adapter] = useDateAdapter({
         format: 'YYYY-MM-DD',

--- a/packages/valko-ui-components/src/__test__/useNotification.spec.ts
+++ b/packages/valko-ui-components/src/__test__/useNotification.spec.ts
@@ -312,4 +312,13 @@ describe('useNotification composable', () => {
       expect(notification?.className).toContain('w-52')
     })
   })
+
+  describe('When text prop changes', () => {
+    it('should throw an error if text prop is not provided', () => {
+      // @ts-expect-error: Text is required, we are forcing it to be missing to test error handling
+      expect(() => useNotification({ duration: 3000 })).toThrow('Property "text" is required')
+    })
+  })
 })
+
+

--- a/packages/valko-ui-components/src/__test__/useTimeAdapter.spec.ts
+++ b/packages/valko-ui-components/src/__test__/useTimeAdapter.spec.ts
@@ -3,8 +3,9 @@ import useTimeAdapter from '#valkoui/composables/useTimeAdapter'
 describe('useTimeAdapter composable', () => {
   const mockTime = new Date(2024, 9, 18, 14, 5, 9)
 
-  beforeAll(() => {
-    vi.useFakeTimers().setSystemTime(mockTime.getTime())
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(mockTime.getTime())
   })
 
   afterAll(() => {
@@ -19,6 +20,30 @@ describe('useTimeAdapter composable', () => {
   })
 
   describe('ParsedModel', () => {
+    it('should fallback to default format HH:mm:ss if format is missing', () => {
+      const [, parsedModel] = useTimeAdapter({})
+
+      expect(parsedModel.value).toBe('14:05:09')
+    })
+
+    it('should fallback to 12 for hours12 if hour is 0 (midnight)', () => {
+      const midnight = new Date(2024, 9, 18, 0, 0, 0)
+      vi.setSystemTime(midnight.getTime())
+      const [, parsedModel] = useTimeAdapter({ format: 'h' })
+
+      expect(parsedModel.value).toBe('12')
+      vi.useRealTimers()
+    })
+
+    it('should fallback to 12 for hours12 if hour is 12 (noon)', () => {
+      const noon = new Date(2024, 9, 18, 12, 0, 0)
+      vi.setSystemTime(noon.getTime())
+      const [, parsedModel] = useTimeAdapter({ format: 'h' })
+
+      expect(parsedModel.value).toBe('12')
+      vi.useRealTimers()
+    })
+
     it('should format time as HH (24-hour padded)', () => {
       const [ , parsedModel ] = useTimeAdapter({ format: 'HH' })
       expect(parsedModel.value).toBe('14')
@@ -70,113 +95,344 @@ describe('useTimeAdapter composable', () => {
     })
   })
 
-  describe('Adapter methods', () => {
-    describe('setDisplayUnit', () => {
-      it('should correctly update the parsed model when setting hours', () => {
-        const [, parsedModel, { setDisplayUnit }] = useTimeAdapter({ format: 'HH:mm:ss' })
-        setDisplayUnit('h', 14)
-        expect(parsedModel.value).toContain('14')
-      })
+  describe('formattedTime', () => {
 
-      it('should correctly update the parsed model when setting minutes', () => {
-        const [, parsedModel, { setDisplayUnit }] = useTimeAdapter({ format: 'HH:mm:ss' })
-        setDisplayUnit('m', 5)
-        expect(parsedModel.value).toContain('05')
-      })
+    it('should display 12 for midnight in 12-hour format', () => {
+      const midnight = new Date(2024, 9, 18, 0, 0, 0)
+      vi.setSystemTime(midnight.getTime())
+      const [,, { formattedTime }] = useTimeAdapter({ format: 'h:mm A' })
 
-      it('should correctly update the parsed model when setting seconds', () => {
-        const [, parsedModel, { setDisplayUnit }] = useTimeAdapter({ format: 'HH:mm:ss' })
-        setDisplayUnit('s', 9)
-        expect(parsedModel.value).toContain('09')
-      })
+      expect(formattedTime.value.display.hours).toBe(12)
+      vi.useRealTimers()
     })
 
-    describe('onSelectAMPM', () => {
-      it('should switch to AM', () => {
-        const [, , { onSelectAMPM, period }] = useTimeAdapter({ format: 'hh:mm:ss A' })
-        onSelectAMPM('AM')
-        expect(period.value).toBe('AM')
-      })
+    it('should fallback to 24-hour display if format does not include h', () => {
+      const [,, { formattedTime }] = useTimeAdapter({})
 
-      it('should switch to PM', () => {
-        const [, , { onSelectAMPM, period }] = useTimeAdapter({ format: 'hh:mm:ss A' })
-        onSelectAMPM('PM')
-        expect(period.value).toBe('PM')
-      })
+      expect(formattedTime.value.display.hours).toBe(14)
     })
 
-    describe('onSelectTime', () => {
-      it('should correctly update the model with a selected hour', () => {
-        const [model, , { setDisplayUnit, onSelectTime }] = useTimeAdapter({ format: 'HH:mm:ss' })
+    it('should use 12-hour display if format includes h', () => {
+      const [,, { formattedTime }] = useTimeAdapter({ format: 'h:mm A' })
 
-        setDisplayUnit('h', 15)
-        onSelectTime()
+      expect(formattedTime.value.display.hours).toBe(2)
+    })
+  })
 
-        const updatedTime = new Date(mockTime)
-        updatedTime.setHours(15)
-
-        expect(model.value).toBe(updatedTime.getTime())
-      })
-
-      it('should correctly update the model with a selected minute', () => {
-        const [model, , { setDisplayUnit, onSelectTime }] = useTimeAdapter({ format: 'HH:mm:ss' })
-
-        setDisplayUnit('m', 45)
-        onSelectTime()
-
-        const updatedTime = new Date(mockTime)
-        updatedTime.setMinutes(45)
-
-        expect(model.value).toBe(updatedTime.getTime())
-      })
-
-      it('should correctly update the model with a selected second', () => {
-        const [model, , { setDisplayUnit, onSelectTime }] = useTimeAdapter({ format: 'HH:mm:ss' })
-
-        setDisplayUnit('s', 30)
-        onSelectTime()
-
-        const updatedTime = new Date(mockTime)
-        updatedTime.setSeconds(30)
-
-        expect(model.value).toBe(updatedTime.getTime())
-      })
+  describe('setDisplayUnit', () => {
+    it('should correctly update the parsed model when setting hours', () => {
+      const [, parsedModel, { setDisplayUnit }] = useTimeAdapter({ format: 'HH:mm:ss' })
+      setDisplayUnit('h', 14)
+      expect(parsedModel.value).toContain('14')
     })
 
-    describe('isTimeDisabled', () => {
-      let isTimeDisabled: (hours: number, minutes?: number) => boolean | undefined
+    it('should correctly update the parsed model when setting minutes', () => {
+      const [, parsedModel, { setDisplayUnit }] = useTimeAdapter({ format: 'HH:mm:ss' })
+      setDisplayUnit('m', 5)
+      expect(parsedModel.value).toContain('05')
+    })
 
-      beforeEach(() => {
-        [, , { isTimeDisabled }] = useTimeAdapter({
-          format: 'HH:mm:ss',
-          disabledTimes: [
-            new Date(2024, 10, 21, 14, 0).getTime(), // 14:00
-            new Date(2024, 10, 21, 15, 30).getTime(), // 15:30
-            new Date(2024, 10, 21, 23, 45).getTime() // 23:45
-          ]
-        })
+    it('should correctly update the parsed model when setting seconds', () => {
+      const [, parsedModel, { setDisplayUnit }] = useTimeAdapter({ format: 'HH:mm:ss' })
+      setDisplayUnit('s', 9)
+      expect(parsedModel.value).toContain('09')
+    })
+  })
+
+  describe('onSelectAMPM', () => {
+    it('should switch to AM', () => {
+      const [, , { onSelectAMPM, period }] = useTimeAdapter({ format: 'hh:mm:ss A' })
+      onSelectAMPM('AM')
+      expect(period.value).toBe('AM')
+    })
+
+    it('should switch to PM', () => {
+      const [, , { onSelectAMPM, period }] = useTimeAdapter({ format: 'hh:mm:ss A' })
+      onSelectAMPM('PM')
+      expect(period.value).toBe('PM')
+    })
+
+    it('should set hours using the ternary (AM branch)', () => {
+      const [,, ctx] = useTimeAdapter({ format: 'hh:mm:ss A' })
+      ctx.setDisplayUnit('h', 13)
+      ctx.onSelectAMPM('AM')
+      expect(ctx.formattedTime.value.display.hours).toBe(1)
+    })
+
+    it('should set parsedModel correctly for AM branch', () => {
+      const [ , parsedModel, ctx ] = useTimeAdapter({ format: 'hh:mm:ss A' })
+      ctx.setDisplayUnit('h', 13)
+      ctx.onSelectAMPM('AM')
+      ctx.onSelectTime()
+      expect(parsedModel.value.startsWith('01')).toBe(true)
+    })
+
+    it('should set hours using the ternary (PM branch)', () => {
+      const [,, ctx] = useTimeAdapter({ format: 'hh:mm:ss A' })
+      ctx.setDisplayUnit('h', 1)
+      ctx.onSelectAMPM('PM')
+      expect(ctx.formattedTime.value.display.hours).toBe(1)
+    })
+
+    it('should set parsedModel correctly for PM branch', () => {
+      const [ , parsedModel, ctx ] = useTimeAdapter({ format: 'HH:mm:ss' })
+      ctx.setDisplayUnit('h', 1)
+      ctx.onSelectAMPM('PM')
+      ctx.onSelectTime()
+      const hour = Number(parsedModel.value.split(':')[0])
+      expect(hour).toBe(13)
+    })
+
+    it('should set parsedModel correctly when tempTime exists', () => {
+      const [ , parsedModel, ctx ] = useTimeAdapter({ format: 'HH:mm:ss' })
+      ctx.setDisplayUnit('h', 5)
+      ctx.onSelectAMPM('PM')
+      ctx.onSelectTime()
+      const hour = Number(parsedModel.value.split(':')[0])
+      expect(hour).toBe(17)
+    })
+
+    it('should set hours on tempTime if tempTime exists', () => {
+      const [,, ctx] = useTimeAdapter({ format: 'hh:mm:ss A' })
+      ctx.setDisplayUnit('h', 5)
+      ctx.onSelectAMPM('PM')
+      expect(ctx.formattedTime.value.display.hours).toBe(5)
+    })
+
+    it('should set parsedModel correctly when tempTime exists', () => {
+      const [ , parsedModel, ctx ] = useTimeAdapter({ format: 'HH:mm:ss' })
+      ctx.setDisplayUnit('h', 5)
+      ctx.onSelectAMPM('PM')
+      ctx.onSelectTime()
+      const hour = Number(parsedModel.value.split(':')[0])
+      expect(hour).toBe(17)
+    })
+
+    it('should set hours on new tempTime if tempTime does not exist', () => {
+      const [,, ctx] = useTimeAdapter({ format: 'hh:mm:ss A' })
+      ctx.onSelectAMPM('AM')
+      expect(ctx.formattedTime.value.display.hours).toBe(2)
+    })
+
+    it('should set parsedModel correctly when tempTime does not exist', () => {
+      const [ , parsedModel, ctx ] = useTimeAdapter({ format: 'hh:mm:ss A' })
+      ctx.onSelectAMPM('AM')
+      ctx.onSelectTime()
+      expect(parsedModel.value.endsWith('AM')).toBe(true)
+    })
+  })
+
+  describe('onSelectTime', () => {
+    it('should correctly update the model with a selected hour', () => {
+      const [model, , { setDisplayUnit, onSelectTime }] = useTimeAdapter({ format: 'HH:mm:ss' })
+
+      setDisplayUnit('h', 15)
+      onSelectTime()
+
+      const updatedTime = new Date(mockTime)
+      updatedTime.setHours(15)
+
+      expect(model.value).toBe(updatedTime.getTime())
+    })
+
+    it('should correctly update the model with a selected minute', () => {
+      const [model, , { setDisplayUnit, onSelectTime }] = useTimeAdapter({ format: 'HH:mm:ss' })
+
+      setDisplayUnit('m', 45)
+      onSelectTime()
+
+      const updatedTime = new Date(mockTime)
+      updatedTime.setMinutes(45)
+
+      expect(model.value).toBe(updatedTime.getTime())
+    })
+
+    it('should correctly update the model with a selected second', () => {
+      const [model, , { setDisplayUnit, onSelectTime }] = useTimeAdapter({ format: 'HH:mm:ss' })
+
+      setDisplayUnit('s', 30)
+      onSelectTime()
+
+      const updatedTime = new Date(mockTime)
+      updatedTime.setSeconds(30)
+
+      expect(model.value).toBe(updatedTime.getTime())
+    })
+
+    it('should not update the model if tempTime is null', () => {
+      const [model, , { onSelectTime }] = useTimeAdapter({ format: 'HH:mm:ss' })
+      const original = model.value
+      onSelectTime()
+      expect(model.value).toBe(original)
+    })
+  })
+
+  describe('isTimeDisabled', () => {
+    let isTimeDisabled: (hours: number, minutes?: number) => boolean | undefined
+
+    beforeEach(() => {
+      const result = useTimeAdapter({
+        format: 'HH:mm:ss',
+        disabledTimes: [
+          new Date(2024, 10, 21, 14, 0).getTime(),
+          new Date(2024, 10, 21, 15, 30).getTime(),
+          new Date(2024, 10, 21, 23, 45).getTime()
+        ]
       })
 
-      it('should disable a specific hour', () => {
-        expect(isTimeDisabled(14)).toBe(true)
+      isTimeDisabled = result[2].isTimeDisabled
+    })
+
+    it('should disable a specific hour', () => {
+      expect(isTimeDisabled(14)).toBe(true)
+    })
+
+    it('should work when no disabledTimes are provided', () => {
+      const [, , { isTimeDisabled }] = useTimeAdapter({
+        format: 'HH:mm:ss',
+        disabledTimes: []
       })
+      expect(isTimeDisabled(14)).toBe(false)
+    })
 
-      // it('should disable a specific minute', () => {
-      //   expect(isTimeDisabled(15, 30)).toBe(true)
-      // })
+    it('should use 24-hour logic when format is empty string', () => {
+      const [, , { isTimeDisabled }] = useTimeAdapter({ format: '' })
+      expect(isTimeDisabled(10)).toBe(false)
+    })
 
-      // it('should disable a specific hour, minute combination', () => {
-      //   expect(isTimeDisabled(23, 45)).toBe(true)
-      // })
+    it('should use 24-hour logic when format is undefined', () => {
+      const [, , { isTimeDisabled }] = useTimeAdapter({})
+      expect(isTimeDisabled(10)).toBe(false)
+    })
 
-      it('should work when no disabledTimes are provided', () => {
-        [, , { isTimeDisabled }] = useTimeAdapter({
-          format: 'HH:mm:ss',
-          disabledTimes: []
-        })
+    it('should use convertTo24Hour for 12-hour format (AM)', () => {
+      const [, , { isTimeDisabled }] = useTimeAdapter({ format: 'h:mm A' })
+      expect(isTimeDisabled(12)).toBe(false)
+    })
 
-        expect(isTimeDisabled(14)).toBe(false)
-      })
+    it('should use convertTo24Hour for 12-hour format (PM)', () => {
+      const [, , { isTimeDisabled }] = useTimeAdapter({ format: 'h:mm A' })
+      expect(isTimeDisabled(1)).toBe(false)
+    })
+
+    it('should not disable minDate boundary when minTime and maxTime are provided', () => {
+      const minDate = new Date(Date.UTC(2024, 9, 18, 13, 0, 0))
+      const maxDate = new Date(Date.UTC(2024, 9, 18, 15, 0, 0))
+      const minTime = Math.floor(minDate.getTime() / 1000)
+      const maxTime = Math.floor(maxDate.getTime() / 1000)
+      const [, , { isTimeDisabled }] = useTimeAdapter({ format: 'HH:mm:ss', minTime, maxTime })
+      expect(isTimeDisabled(minDate.getUTCHours(), minDate.getUTCMinutes())).toBe(false)
+    })
+
+    it('should not disable maxDate boundary when minTime and maxTime are provided', () => {
+      const minDate = new Date(Date.UTC(2024, 9, 18, 13, 0, 0))
+      const maxDate = new Date(Date.UTC(2024, 9, 18, 15, 0, 0))
+      const minTime = Math.floor(minDate.getTime() / 1000)
+      const maxTime = Math.floor(maxDate.getTime() / 1000)
+      const [, , { isTimeDisabled }] = useTimeAdapter({ format: 'HH:mm:ss', minTime, maxTime })
+      expect(isTimeDisabled(maxDate.getUTCHours(), maxDate.getUTCMinutes())).toBe(false)
+    })
+
+    it('should not disable value between minDate and maxDate when minTime and maxTime are provided', () => {
+      const minDate = new Date(Date.UTC(2024, 9, 18, 13, 0, 0))
+      const maxDate = new Date(Date.UTC(2024, 9, 18, 15, 0, 0))
+      const minTime = Math.floor(minDate.getTime() / 1000)
+      const maxTime = Math.floor(maxDate.getTime() / 1000)
+      const [, , { isTimeDisabled }] = useTimeAdapter({ format: 'HH:mm:ss', minTime, maxTime })
+      expect(isTimeDisabled(14, 0)).toBe(false)
+    })
+
+    it('should return true if below minTime', () => {
+      const minTime = Math.floor(new Date(2024, 9, 18, 15, 0, 0).getTime() / 1000)
+      const [, , { isTimeDisabled }] = useTimeAdapter({ format: 'HH:mm:ss', minTime })
+      expect(isTimeDisabled(14, 0)).toBe(true)
+    })
+
+    it('should return true if above maxTime', () => {
+      const maxDate = new Date(Date.UTC(2024, 9, 18, 13, 0, 0))
+      const maxTime = Math.floor(maxDate.getTime() / 1000)
+      const [, , { isTimeDisabled }] = useTimeAdapter({ format: 'HH:mm:ss', maxTime })
+      expect(isTimeDisabled(14, 0)).toBe(true)
+    })
+
+    it('should use convertTo24Hour in disabledTimes logic for 12-hour format', () => {
+      const disabledDate = new Date(Date.UTC(2024, 9, 18, 14, 0, 0))
+      const disabled = Math.floor(disabledDate.getTime() / 1000)
+      const [, , { isTimeDisabled }] = useTimeAdapter({ format: 'h:mm A', disabledTimes: [disabled] })
+      expect(isTimeDisabled(2, 0)).toBe(true)
+    })
+
+    it('should return 0 for convertTo24Hour when h === 12 and period is AM', () => {
+      const minDate = new Date(Date.UTC(2024, 9, 18, 1, 0, 0))
+      const minTime = Math.floor(minDate.getTime() / 1000)
+      const [, , { isTimeDisabled, onSelectAMPM }] = useTimeAdapter({ format: 'h:mm A', minTime })
+      onSelectAMPM('AM')
+      expect(isTimeDisabled(12, 0)).toBe(true)
+    })
+
+    it('should return 12 for convertTo24Hour when h === 12 and period is PM', () => {
+      const minDate = new Date(Date.UTC(2024, 9, 18, 13, 0, 0))
+      const minTime = Math.floor(minDate.getTime() / 1000)
+      const [, , { isTimeDisabled, onSelectAMPM }] = useTimeAdapter({ format: 'h:mm A', minTime })
+      onSelectAMPM('PM')
+      expect(isTimeDisabled(12, 0)).toBe(true)
+    })
+
+    it('should return h + 12 for convertTo24Hour when h !== 12 and period is PM', () => {
+      const minDate = new Date(Date.UTC(2024, 9, 18, 14, 0, 0))
+      const minTime = Math.floor(minDate.getTime() / 1000)
+      const [, , { isTimeDisabled, onSelectAMPM }] = useTimeAdapter({ format: 'h:mm A', minTime })
+      onSelectAMPM('PM')
+      expect(isTimeDisabled(1, 0)).toBe(true)
+    })
+
+    it('should return h for convertTo24Hour when h !== 12 and period is AM', () => {
+      const minDate = new Date(Date.UTC(2024, 9, 18, 2, 0, 0))
+      const minTime = Math.floor(minDate.getTime() / 1000)
+      const [, , { isTimeDisabled, onSelectAMPM }] = useTimeAdapter({ format: 'h:mm A', minTime })
+      onSelectAMPM('AM')
+      expect(isTimeDisabled(1, 0)).toBe(true)
+    })
+
+    it('should cover disabledTimes logic: || 12 fallback', () => {
+      const disabledDate = new Date(Date.UTC(2024, 9, 18, 0, 0, 0))
+      const disabled = Math.floor(disabledDate.getTime() / 1000)
+      const [, , { isTimeDisabled, onSelectAMPM }] = useTimeAdapter({ format: 'h:mm A', disabledTimes: [disabled] })
+      onSelectAMPM('AM')
+      expect(isTimeDisabled(12, 0)).toBe(true)
+    })
+
+    it('should cover disabledTimes logic: AM period branch', () => {
+      const disabledDate = new Date(Date.UTC(2024, 9, 18, 1, 0, 0))
+      const disabled = Math.floor(disabledDate.getTime() / 1000)
+      const [, , { isTimeDisabled, onSelectAMPM }] = useTimeAdapter({ format: 'h:mm A', disabledTimes: [disabled] })
+      onSelectAMPM('AM')
+      expect(isTimeDisabled(1, 0)).toBe(true)
+    })
+
+    it('should return false for isSpecificallyDisabled fallback', () => {
+      const [, , { isTimeDisabled }] = useTimeAdapter({ format: 'HH:mm:ss' })
+      expect(isTimeDisabled(10)).toBe(false)
+    })
+  })
+
+  describe('parsedPeriod', () => {
+    it('should return AM for morning hours', () => {
+      const morningTime = new Date(2024, 9, 18, 9, 0, 0)
+      vi.setSystemTime(morningTime.getTime())
+      const [,, { period }] = useTimeAdapter({ format: 'HH:mm:ss' })
+
+      expect(period.value).toBe('AM')
+      vi.useRealTimers()
+    })
+
+    it('should return PM for afternoon hours', () => {
+      const afternoonTime = new Date(2024, 9, 18, 15, 0, 0)
+      vi.setSystemTime(afternoonTime.getTime())
+      const [,, { period }] = useTimeAdapter({ format: 'HH:mm:ss' })
+
+      expect(period.value).toBe('PM')
+      vi.useRealTimers()
     })
   })
 })

--- a/packages/valko-ui-components/src/__test__/useTimeAdapter.spec.ts
+++ b/packages/valko-ui-components/src/__test__/useTimeAdapter.spec.ts
@@ -435,4 +435,16 @@ describe('useTimeAdapter composable', () => {
       vi.useRealTimers()
     })
   })
+
+  describe('Time selection flow', () => {
+    it('should use temp time to form dates while updating time', () => {
+      const [,parsedModel, { setDisplayUnit, onSelectAMPM, onSelectTime }] = useTimeAdapter({ format: 'h:mm A' })
+      onSelectAMPM('AM')
+      setDisplayUnit('h', 1)
+      setDisplayUnit('m', 30)
+      onSelectTime()
+
+      expect(parsedModel.value).toBe('1:30 AM')
+    })
+  })
 })

--- a/packages/valko-ui-components/src/components/Breadcrumbs.vue
+++ b/packages/valko-ui-components/src/components/Breadcrumbs.vue
@@ -45,7 +45,7 @@ const selectIcon = (separator: string) => separator.length > 2
         <a
           v-if="crumb.key !== lastCrumbKey"
           role="link"
-          :tabindex="crumb.key !== lastCrumbKey ? 0 : -1"
+          :tabindex="crumb.disabled ? -1 : 0"
           :class="s.link({ class: styleSlots?.link })"
           :data-disabled="crumb.disabled"
           :aria-disabled="crumb.disabled || undefined"

--- a/packages/valko-ui-components/src/components/Calendar.vue
+++ b/packages/valko-ui-components/src/components/Calendar.vue
@@ -52,9 +52,7 @@ const availableViews = ref<DisplayView[]>(getAvailableViews())
 const currentView = ref<DisplayView>(availableViews.value[0])
 const selectionType = ref<SelectionType>(getSelectionType())
 
-const onViewChange = (view: DisplayView) => {
-  if (availableViews.value.includes(view)) currentView.value = view
-}
+const onViewChange = (view: DisplayView) => currentView.value = view
 
 const onSelectYear = (year: number) => {
   const result = props.adapter.onSelectYear(year)
@@ -104,7 +102,10 @@ watch(() => props.format, () => {
 </script>
 
 <template>
-  <div :class="s.container({ class: styleSlots?.container })">
+  <div
+    :class="s.container({ class: styleSlots?.container })"
+    :data-selection-type="selectionType"
+  >
     <vk-calendar-day-view
       v-if="currentView === 'days'"
       v-bind="props"

--- a/packages/valko-ui-components/src/components/Checkbox.vue
+++ b/packages/valko-ui-components/src/components/Checkbox.vue
@@ -74,7 +74,6 @@ const onClick = () => {
         :name="name"
         :disabled="disabled"
         :class="s.input({ class: styleSlots?.input })"
-        @click.prevent=""
       >
       <label
         :for="inputId"

--- a/packages/valko-ui-components/src/components/Datepicker.vue
+++ b/packages/valko-ui-components/src/components/Datepicker.vue
@@ -45,7 +45,6 @@ onBeforeUnmount(() => document.removeEventListener('mousedown', handleClickOutsi
       readonly
       cursor="pointer"
       @focus="emit('open')"
-      @right-icon-click="emit('open')"
     >
       <template #right-icon>
         <vk-icon name="calendar" />

--- a/packages/valko-ui-components/src/components/Drawer.vue
+++ b/packages/valko-ui-components/src/components/Drawer.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import { ref, computed, useId } from 'vue'
-import { TransitionRoot, TransitionChild, Dialog, DialogPanel, DialogTitle } from '@headlessui/vue'
+import { ref, computed } from 'vue'
+import { TransitionRoot, TransitionChild, Dialog, DialogPanel, DialogTitle, DialogDescription } from '@headlessui/vue'
 import type { DrawerProps } from '#valkoui/types/Drawer'
 import styles from '#valkoui/styles/Drawer.styles.ts'
 import VkIcon from './Icon.vue'
@@ -24,7 +24,6 @@ const emit = defineEmits(['close'])
 const s = computed(() => styles(props))
 
 const containerRef = ref(null)
-const descriptionId = useId()
 
 const closeDrawer = () => { if (props.closable) emit('close') }
 
@@ -89,7 +88,6 @@ const transitionClasses = computed(() => {
       :class="s.dialog({ class: styleSlots?.dialog })"
       :initial-focus="containerRef"
       :aria-modal="true"
-      :aria-describedby="ariaDescription ? descriptionId : undefined"
       :aria-labelledby="ariaLabelledBy"
       @close="closeDrawer"
     >
@@ -139,13 +137,12 @@ const transitionClasses = computed(() => {
                 >
                   {{ title }}
                 </dialog-title>
-                <div
+                <dialog-description
                   v-if="ariaDescription"
                   class="sr-only"
-                  :id="descriptionId"
                 >
                   {{ ariaDescription }}
-                </div>
+                </dialog-description>
                 <vk-button
                   v-if="closable"
                   tabindex="-1"

--- a/packages/valko-ui-components/src/components/Dropdown.vue
+++ b/packages/valko-ui-components/src/components/Dropdown.vue
@@ -43,7 +43,6 @@ const onClick = (event: MouseEvent) => {
 }
 
 const onItemClick = (item: Item) => {
-  if (item.disabled) return
   emit('itemClick', item)
   item.onClick?.()
   open.value = false

--- a/packages/valko-ui-components/src/components/Modal.vue
+++ b/packages/valko-ui-components/src/components/Modal.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import { ref, useId, computed } from 'vue'
-import { TransitionRoot, TransitionChild, Dialog, DialogPanel, DialogTitle } from '@headlessui/vue'
+import { ref, computed } from 'vue'
+import { TransitionRoot, TransitionChild, Dialog, DialogPanel, DialogTitle, DialogDescription } from '@headlessui/vue'
 import type { ModalProps } from '#valkoui/types/Modal'
 import styles from '#valkoui/styles/Modal.styles.ts'
 import VkIcon from './Icon.vue'
@@ -22,7 +22,6 @@ const emit = defineEmits(['close'])
 const s = computed(() => styles(props))
 
 const containerRef = ref(null)
-const descriptionId = useId()
 
 const closeModal = () => { if (props.closable) emit('close') }
 </script>
@@ -37,7 +36,6 @@ const closeModal = () => { if (props.closable) emit('close') }
       :class="s.dialog({ class: styleSlots?.dialog })"
       :initial-focus="containerRef"
       :aria-modal="true"
-      :aria-describedby="ariaDescription ? descriptionId : undefined"
       :aria-labelledby="ariaLabelledBy"
       @close="closeModal"
     >
@@ -80,13 +78,12 @@ const closeModal = () => { if (props.closable) emit('close') }
                 >
                   {{ title }}
                 </dialog-title>
-                <div
+                <dialog-description
                   v-if="ariaDescription"
                   class="sr-only"
-                  :id="descriptionId"
                 >
                   {{ ariaDescription }}
-                </div>
+                </dialog-description>
                 <vk-button
                   v-if="closable"
                   tabindex="-1"

--- a/packages/valko-ui-components/src/components/Popover.vue
+++ b/packages/valko-ui-components/src/components/Popover.vue
@@ -74,6 +74,7 @@ onBeforeUnmount(() => {
   <div
     ref="rootRef"
     :class="s.container({ class: styleSlots?.container })"
+    :data-open="isOpen"
   >
     <div
       :class="s.slotContainer({ class: styleSlots?.slotContainer })"

--- a/packages/valko-ui-components/src/components/Select.vue
+++ b/packages/valko-ui-components/src/components/Select.vue
@@ -111,9 +111,10 @@ const handleKeyDown = (e: KeyboardEvent) => {
     else handleSingleSelection(item.value)
   }
 
-  if (!formulaMap[currentKey as keyof typeof formulaMap]) return
+  const move = formulaMap[currentKey as keyof typeof formulaMap]
+  if (!move) return
 
-  highlightedIndex.value = formulaMap[currentKey as keyof typeof formulaMap]()
+  highlightedIndex.value = move()
   nextTick(() => itemRefs.value[highlightedIndex.value]?.scrollIntoView({ block: 'nearest' }))
 }
 

--- a/packages/valko-ui-components/src/components/Select.vue
+++ b/packages/valko-ui-components/src/components/Select.vue
@@ -111,6 +111,8 @@ const handleKeyDown = (e: KeyboardEvent) => {
     else handleSingleSelection(item.value)
   }
 
+  if (!formulaMap[currentKey as keyof typeof formulaMap]) return
+
   highlightedIndex.value = formulaMap[currentKey as keyof typeof formulaMap]()
   nextTick(() => itemRefs.value[highlightedIndex.value]?.scrollIntoView({ block: 'nearest' }))
 }

--- a/packages/valko-ui-components/src/components/Timepicker.vue
+++ b/packages/valko-ui-components/src/components/Timepicker.vue
@@ -30,7 +30,7 @@ const handleClickOutside = (event: MouseEvent) => {
 }
 
 onMounted(() => nextTick(() => document.addEventListener('mousedown', handleClickOutside, true)))
-onBeforeUnmount(() => document.addEventListener('mousedown', handleClickOutside, true))
+onBeforeUnmount(() => document.removeEventListener('mousedown', handleClickOutside, true))
 </script>
 
 <template>
@@ -45,7 +45,6 @@ onBeforeUnmount(() => document.addEventListener('mousedown', handleClickOutside,
       :class="s.input({ class: styleSlots?.input })"
       readonly
       @focus="emit('open')"
-      @right-icon-click="emit('open')"
     >
       <template #right-icon>
         <vk-icon name="clock-2" />

--- a/packages/valko-ui-components/src/composables/useTimeAdapter.ts
+++ b/packages/valko-ui-components/src/composables/useTimeAdapter.ts
@@ -114,13 +114,7 @@ const useTimeAdapter = (props: TimeAdapterProps | Ref<TimeAdapterProps>): TimeAd
       s: 'setSeconds'
     }
 
-    const helperDate = new Date(
-      tempTime.value
-        ? tempTime.value
-        : model.value
-          ? model.value
-          : 0
-    )
+    const helperDate = new Date(tempTime.value || model.value)
     helperDate[unitMap[unit]](value)
 
     tempTime.value = helperDate

--- a/packages/valko-ui-components/src/styles/Drawer.styles.ts
+++ b/packages/valko-ui-components/src/styles/Drawer.styles.ts
@@ -18,6 +18,7 @@ const drawer = tv({
       'inset-0'
     ],
     dialog: [
+      'vk-drawer__dialog',
       'relative',
       'z-50'
     ],

--- a/packages/valko-ui-components/src/styles/Dropdown.styles.ts
+++ b/packages/valko-ui-components/src/styles/Dropdown.styles.ts
@@ -20,6 +20,7 @@ const dropdown = tv({
       'bg-surface-container'
     ],
     itemsMenu: [
+      'vk-dropdown__items-menu',
       'p-2'
     ],
     triggerButton: [

--- a/packages/valko-ui-components/src/styles/Input.styles.ts
+++ b/packages/valko-ui-components/src/styles/Input.styles.ts
@@ -59,6 +59,7 @@ const input = tv({
       'px-4'
     ],
     icons: [
+      'vk-input__icons',
       'cursor-pointer',
       'text-on-surface-variant',
       'absolute',

--- a/packages/valko-ui-components/src/styles/Modal.styles.ts
+++ b/packages/valko-ui-components/src/styles/Modal.styles.ts
@@ -14,6 +14,7 @@ const modal = tv({
       'inset-0'
     ],
     dialog: [
+      'vk-modal__dialog',
       'relative',
       'z-50'
     ],

--- a/packages/valko-ui-components/src/styles/Textarea.styles.ts
+++ b/packages/valko-ui-components/src/styles/Textarea.styles.ts
@@ -76,9 +76,11 @@ const textarea = tv({
       'px-4'
     ],
     leftIcon: [
+      'vk-textarea__left-icon',
       'left-3'
     ],
     rightIcon: [
+      'vk-textarea__right-icon',
       'right-3'
     ],
     icons: [

--- a/packages/valko-ui-components/src/styles/Time.styles.ts
+++ b/packages/valko-ui-components/src/styles/Time.styles.ts
@@ -24,6 +24,7 @@ const time = tv({
       'justify-between'
     ],
     unitContainer: [
+      'vk-time__unit-container',
       'border-r',
       'border-outlined',
       'last:border-r-0',

--- a/packages/valko-ui-components/tsconfig.json
+++ b/packages/valko-ui-components/tsconfig.json
@@ -11,7 +11,7 @@
     "useDefineForClassFields": true,
     "module": "ESNext",
     "lib": [
-      "ES2021",
+      "ES2022",
       "DOM",
       "DOM.Iterable"
     ],


### PR DESCRIPTION
This PR expands test coverage for core components and composables, aiming to cover as much of the library as possible for robust validation.

### Components Progress:
- [x] Alert
- [x] Avatar
- [x] Badge
- [x] Breadcrumbs
- [x] Button
- [x] Calendar
- [x] CalendarDayView
- [x] CalendarHeader
- [x] CalendarMonthView
- [x] CalendarYearView
- [x] Card
- [x] CardBody
- [x] CardFooter
- [x] CardHeader
- [x] CardImage
- [x] Checkbox
- [x] Collapse
- [x] CollapseItem
- [x] DataTable
- [x] Datepicker
- [x] Divider
- [x] Drawer
- [x] Dropdown
- [x] Icon
- [x] Input
- [x] Menu
- [x] Modal
- [x] Navbar
- [x] Pagination
- [x] Popover
- [x] Progressbar
- [x] Radio
- [x] Range
- [x] Select
- [x] Spinner
- [x] Switch
- [x] Table
- [x] Tabs
- [x] Tag
- [x] Textarea
- [x] Time
- [x] Timepicker
- [x] Tooltip

## Known Coverage Gaps

- **Popover:** Can't test fallbacks for `selectedPlacement` & `selectedAlignment` due to environment/window sizing limitations.
- **Calendar:** `@select-year="onSelectYear"` branch not covered, unclear why.
- **Tabs:** Refs are readonly, cannot force null for else paths in `moveCursor`.
- **Datatable:** Needs refactor for better testability; current code is not reactive enough.
- **Select:** Unable to cover else path in `closeDropdownOnOutsideClick`, likely due to guard logic.
- **UseNotification:** Cannot reliably test DOM removal or `stopOnFocus` due to test environment and Toastify internals.
- **UseTimeAdapter:** `setUnitDisplay` timezone logic is not reliably testable without refactor.